### PR TITLE
[feature/SwipeHomeVC] XLPagerTabStrip 적용

### DIFF
--- a/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
@@ -8,9 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		641F2B31282E21860007C401 /* HomeTaskCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641F2B30282E21860007C401 /* HomeTaskCell.swift */; };
+		643478D5283167EE0038A932 /* HomeParentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643478D4283167EE0038A932 /* HomeParentViewController.swift */; };
 		644D9BFA282544E9000C80BB /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644D9BF9282544E9000C80BB /* Task.swift */; };
-		645949E32827EA5E00D23DA9 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645949E22827EA5E00D23DA9 /* HomeViewController.swift */; };
-		645949E52827EDCF00D23DA9 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645949E42827EDCF00D23DA9 /* HomeView.swift */; };
+		645949E32827EA5E00D23DA9 /* HomeChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645949E22827EA5E00D23DA9 /* HomeChildViewController.swift */; };
+		645949E52827EDCF00D23DA9 /* HomeChildView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645949E42827EDCF00D23DA9 /* HomeChildView.swift */; };
 		64639E69282539AF008311D4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64639E68282539AF008311D4 /* AppDelegate.swift */; };
 		64639E70282539AF008311D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 64639E6E282539AF008311D4 /* Main.storyboard */; };
 		64639E72282539B3008311D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 64639E71282539B3008311D4 /* Assets.xcassets */; };
@@ -24,9 +25,10 @@
 		4046C9957ABB88F6D8DFA5BD /* Pods_CapstoneProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CapstoneProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41F516136939B358E0E5823F /* Pods-CapstoneProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CapstoneProject.release.xcconfig"; path = "Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject.release.xcconfig"; sourceTree = "<group>"; };
 		641F2B30282E21860007C401 /* HomeTaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTaskCell.swift; sourceTree = "<group>"; };
+		643478D4283167EE0038A932 /* HomeParentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeParentViewController.swift; sourceTree = "<group>"; };
 		644D9BF9282544E9000C80BB /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
-		645949E22827EA5E00D23DA9 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
-		645949E42827EDCF00D23DA9 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		645949E22827EA5E00D23DA9 /* HomeChildViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeChildViewController.swift; sourceTree = "<group>"; };
+		645949E42827EDCF00D23DA9 /* HomeChildView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeChildView.swift; sourceTree = "<group>"; };
 		64639E65282539AF008311D4 /* CapstoneProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CapstoneProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		64639E68282539AF008311D4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		64639E6F282539AF008311D4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -56,7 +58,6 @@
 				752E95D24C7D97C4A931C0C1 /* Pods-CapstoneProject.debug.xcconfig */,
 				41F516136939B358E0E5823F /* Pods-CapstoneProject.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -82,7 +83,7 @@
 			children = (
 				64639E6E282539AF008311D4 /* Main.storyboard */,
 				64639E73282539B3008311D4 /* LaunchScreen.storyboard */,
-				645949E42827EDCF00D23DA9 /* HomeView.swift */,
+				645949E42827EDCF00D23DA9 /* HomeChildView.swift */,
 				641F2B30282E21860007C401 /* HomeTaskCell.swift */,
 				64BDC6102830ED0C004E00D3 /* AddTaskView.swift */,
 			);
@@ -100,7 +101,8 @@
 		644D9BF828254089000C80BB /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				645949E22827EA5E00D23DA9 /* HomeViewController.swift */,
+				643478D4283167EE0038A932 /* HomeParentViewController.swift */,
+				645949E22827EA5E00D23DA9 /* HomeChildViewController.swift */,
 				64BDC6122830EDA9004E00D3 /* AddTaskViewController.swift */,
 			);
 			path = Controllers;
@@ -262,10 +264,11 @@
 				64BDC6132830EDA9004E00D3 /* AddTaskViewController.swift in Sources */,
 				644D9BFA282544E9000C80BB /* Task.swift in Sources */,
 				641F2B31282E21860007C401 /* HomeTaskCell.swift in Sources */,
+				643478D5283167EE0038A932 /* HomeParentViewController.swift in Sources */,
 				64BDC6112830ED0C004E00D3 /* AddTaskView.swift in Sources */,
-				645949E52827EDCF00D23DA9 /* HomeView.swift in Sources */,
+				645949E52827EDCF00D23DA9 /* HomeChildView.swift in Sources */,
 				64639E69282539AF008311D4 /* AppDelegate.swift in Sources */,
-				645949E32827EA5E00D23DA9 /* HomeViewController.swift in Sources */,
+				645949E32827EA5E00D23DA9 /* HomeChildViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
@@ -17,9 +17,12 @@
 		64639E75282539B3008311D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 64639E73282539B3008311D4 /* LaunchScreen.storyboard */; };
 		64BDC6112830ED0C004E00D3 /* AddTaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDC6102830ED0C004E00D3 /* AddTaskView.swift */; };
 		64BDC6132830EDA9004E00D3 /* AddTaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDC6122830EDA9004E00D3 /* AddTaskViewController.swift */; };
+		FBD9636A459A2A63117F3817 /* Pods_CapstoneProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4046C9957ABB88F6D8DFA5BD /* Pods_CapstoneProject.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4046C9957ABB88F6D8DFA5BD /* Pods_CapstoneProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CapstoneProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		41F516136939B358E0E5823F /* Pods-CapstoneProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CapstoneProject.release.xcconfig"; path = "Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject.release.xcconfig"; sourceTree = "<group>"; };
 		641F2B30282E21860007C401 /* HomeTaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTaskCell.swift; sourceTree = "<group>"; };
 		644D9BF9282544E9000C80BB /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		645949E22827EA5E00D23DA9 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -32,6 +35,7 @@
 		64639E76282539B3008311D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		64BDC6102830ED0C004E00D3 /* AddTaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskView.swift; sourceTree = "<group>"; };
 		64BDC6122830EDA9004E00D3 /* AddTaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskViewController.swift; sourceTree = "<group>"; };
+		752E95D24C7D97C4A931C0C1 /* Pods-CapstoneProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CapstoneProject.debug.xcconfig"; path = "Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -39,12 +43,23 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FBD9636A459A2A63117F3817 /* Pods_CapstoneProject.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3520DF10B027D0E9A5E30E29 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				752E95D24C7D97C4A931C0C1 /* Pods-CapstoneProject.debug.xcconfig */,
+				41F516136939B358E0E5823F /* Pods-CapstoneProject.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		644D9BF42825403A000C80BB /* AppDelegate */ = {
 			isa = PBXGroup;
 			children = (
@@ -96,6 +111,8 @@
 			children = (
 				64639E67282539AF008311D4 /* CapstoneProject */,
 				64639E66282539AF008311D4 /* Products */,
+				3520DF10B027D0E9A5E30E29 /* Pods */,
+				9C278B76B0FFFA7DE5F684C5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -119,6 +136,14 @@
 			path = CapstoneProject;
 			sourceTree = "<group>";
 		};
+		9C278B76B0FFFA7DE5F684C5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4046C9957ABB88F6D8DFA5BD /* Pods_CapstoneProject.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -126,9 +151,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 64639E79282539B3008311D4 /* Build configuration list for PBXNativeTarget "CapstoneProject" */;
 			buildPhases = (
+				2215CEDD2C3B22F587C248A6 /* [CP] Check Pods Manifest.lock */,
 				64639E61282539AF008311D4 /* Sources */,
 				64639E62282539AF008311D4 /* Frameworks */,
 				64639E63282539AF008311D4 /* Resources */,
+				DFD716844E50A8BE1AC7B4FA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -184,6 +211,48 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2215CEDD2C3B22F587C248A6 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CapstoneProject-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DFD716844E50A8BE1AC7B4FA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		64639E61282539AF008311D4 /* Sources */ = {
@@ -338,6 +407,7 @@
 		};
 		64639E7A282539B3008311D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 752E95D24C7D97C4A931C0C1 /* Pods-CapstoneProject.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -366,6 +436,7 @@
 		};
 		64639E7B282539B3008311D4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 41F516136939B358E0E5823F /* Pods-CapstoneProject.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
@@ -11,12 +11,13 @@
 		641F2B31282E21860007C401 /* HomeTaskCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641F2B30282E21860007C401 /* HomeTaskCell.swift */; };
 		643478D5283167EE0038A932 /* HomeParentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643478D4283167EE0038A932 /* HomeParentViewController.swift */; };
 		644D9BFA282544E9000C80BB /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644D9BF9282544E9000C80BB /* Task.swift */; };
-		645949E32827EA5E00D23DA9 /* HomeChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645949E22827EA5E00D23DA9 /* HomeChildViewController.swift */; };
+		645949E32827EA5E00D23DA9 /* TomorrowChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645949E22827EA5E00D23DA9 /* TomorrowChildViewController.swift */; };
 		645949E52827EDCF00D23DA9 /* HomeChildView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645949E42827EDCF00D23DA9 /* HomeChildView.swift */; };
 		64639E69282539AF008311D4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64639E68282539AF008311D4 /* AppDelegate.swift */; };
 		64639E70282539AF008311D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 64639E6E282539AF008311D4 /* Main.storyboard */; };
 		64639E72282539B3008311D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 64639E71282539B3008311D4 /* Assets.xcassets */; };
 		64639E75282539B3008311D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 64639E73282539B3008311D4 /* LaunchScreen.storyboard */; };
+		6475840C2837870B00F7E1DD /* ThreeDaysChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6475840B2837870B00F7E1DD /* ThreeDaysChildViewController.swift */; };
 		64BDC6112830ED0C004E00D3 /* AddTaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDC6102830ED0C004E00D3 /* AddTaskView.swift */; };
 		64BDC6132830EDA9004E00D3 /* AddTaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BDC6122830EDA9004E00D3 /* AddTaskViewController.swift */; };
 		FBD9636A459A2A63117F3817 /* Pods_CapstoneProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4046C9957ABB88F6D8DFA5BD /* Pods_CapstoneProject.framework */; };
@@ -29,7 +30,7 @@
 		641F2B30282E21860007C401 /* HomeTaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTaskCell.swift; sourceTree = "<group>"; };
 		643478D4283167EE0038A932 /* HomeParentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeParentViewController.swift; sourceTree = "<group>"; };
 		644D9BF9282544E9000C80BB /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
-		645949E22827EA5E00D23DA9 /* HomeChildViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeChildViewController.swift; sourceTree = "<group>"; };
+		645949E22827EA5E00D23DA9 /* TomorrowChildViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TomorrowChildViewController.swift; sourceTree = "<group>"; };
 		645949E42827EDCF00D23DA9 /* HomeChildView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeChildView.swift; sourceTree = "<group>"; };
 		64639E65282539AF008311D4 /* CapstoneProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CapstoneProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		64639E68282539AF008311D4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -37,6 +38,7 @@
 		64639E71282539B3008311D4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		64639E74282539B3008311D4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		64639E76282539B3008311D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6475840B2837870B00F7E1DD /* ThreeDaysChildViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDaysChildViewController.swift; sourceTree = "<group>"; };
 		64BDC6102830ED0C004E00D3 /* AddTaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskView.swift; sourceTree = "<group>"; };
 		64BDC6122830EDA9004E00D3 /* AddTaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskViewController.swift; sourceTree = "<group>"; };
 		752E95D24C7D97C4A931C0C1 /* Pods-CapstoneProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CapstoneProject.debug.xcconfig"; path = "Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject.debug.xcconfig"; sourceTree = "<group>"; };
@@ -105,7 +107,8 @@
 			isa = PBXGroup;
 			children = (
 				643478D4283167EE0038A932 /* HomeParentViewController.swift */,
-				645949E22827EA5E00D23DA9 /* HomeChildViewController.swift */,
+				645949E22827EA5E00D23DA9 /* TomorrowChildViewController.swift */,
+				6475840B2837870B00F7E1DD /* ThreeDaysChildViewController.swift */,
 				64BDC6122830EDA9004E00D3 /* AddTaskViewController.swift */,
 			);
 			path = Controllers;
@@ -266,13 +269,14 @@
 			files = (
 				64BDC6132830EDA9004E00D3 /* AddTaskViewController.swift in Sources */,
 				644D9BFA282544E9000C80BB /* Task.swift in Sources */,
+				6475840C2837870B00F7E1DD /* ThreeDaysChildViewController.swift in Sources */,
 				641F2B31282E21860007C401 /* HomeTaskCell.swift in Sources */,
 				643478D5283167EE0038A932 /* HomeParentViewController.swift in Sources */,
 				64BDC6112830ED0C004E00D3 /* AddTaskView.swift in Sources */,
 				6401C0BF28376E55000358D1 /* HomeParentView.swift in Sources */,
 				645949E52827EDCF00D23DA9 /* HomeChildView.swift in Sources */,
 				64639E69282539AF008311D4 /* AppDelegate.swift in Sources */,
-				645949E32827EA5E00D23DA9 /* HomeChildViewController.swift in Sources */,
+				645949E32827EA5E00D23DA9 /* TomorrowChildViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject/CapstoneProject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6401C0BF28376E55000358D1 /* HomeParentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6401C0BE28376E55000358D1 /* HomeParentView.swift */; };
 		641F2B31282E21860007C401 /* HomeTaskCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641F2B30282E21860007C401 /* HomeTaskCell.swift */; };
 		643478D5283167EE0038A932 /* HomeParentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643478D4283167EE0038A932 /* HomeParentViewController.swift */; };
 		644D9BFA282544E9000C80BB /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 644D9BF9282544E9000C80BB /* Task.swift */; };
@@ -24,6 +25,7 @@
 /* Begin PBXFileReference section */
 		4046C9957ABB88F6D8DFA5BD /* Pods_CapstoneProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CapstoneProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41F516136939B358E0E5823F /* Pods-CapstoneProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CapstoneProject.release.xcconfig"; path = "Target Support Files/Pods-CapstoneProject/Pods-CapstoneProject.release.xcconfig"; sourceTree = "<group>"; };
+		6401C0BE28376E55000358D1 /* HomeParentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeParentView.swift; sourceTree = "<group>"; };
 		641F2B30282E21860007C401 /* HomeTaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTaskCell.swift; sourceTree = "<group>"; };
 		643478D4283167EE0038A932 /* HomeParentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeParentViewController.swift; sourceTree = "<group>"; };
 		644D9BF9282544E9000C80BB /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 			children = (
 				64639E6E282539AF008311D4 /* Main.storyboard */,
 				64639E73282539B3008311D4 /* LaunchScreen.storyboard */,
+				6401C0BE28376E55000358D1 /* HomeParentView.swift */,
 				645949E42827EDCF00D23DA9 /* HomeChildView.swift */,
 				641F2B30282E21860007C401 /* HomeTaskCell.swift */,
 				64BDC6102830ED0C004E00D3 /* AddTaskView.swift */,
@@ -266,6 +269,7 @@
 				641F2B31282E21860007C401 /* HomeTaskCell.swift in Sources */,
 				643478D5283167EE0038A932 /* HomeParentViewController.swift in Sources */,
 				64BDC6112830ED0C004E00D3 /* AddTaskView.swift in Sources */,
+				6401C0BF28376E55000358D1 /* HomeParentView.swift in Sources */,
 				645949E52827EDCF00D23DA9 /* HomeChildView.swift in Sources */,
 				64639E69282539AF008311D4 /* AppDelegate.swift in Sources */,
 				645949E32827EA5E00D23DA9 /* HomeChildViewController.swift in Sources */,

--- a/CapstoneProject/CapstoneProject.xcworkspace/contents.xcworkspacedata
+++ b/CapstoneProject/CapstoneProject.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:CapstoneProject.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/CapstoneProject/CapstoneProject.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CapstoneProject/CapstoneProject.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
@@ -11,7 +11,7 @@ import XLPagerTabStrip
 public class HomeChildViewController: UIViewController {
     
     // MARK: - Instance Properties
-    public var homeView: HomeChildView! {
+    public var homeChildView: HomeChildView! {
         guard isViewLoaded else { return nil }
         return (view as! HomeChildView)
     }
@@ -20,15 +20,15 @@ public class HomeChildViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
-        homeView.taskCollectionView.delegate = self
-        homeView.taskCollectionView.dataSource = self
+        homeChildView.taskCollectionView.delegate = self
+        homeChildView.taskCollectionView.dataSource = self
         
         setupRemainingLabels()
     }
     
     private func setupRemainingLabels() {
         let remainingTime: Int = 10
-        homeView.remainingTimeLabel.text = "\(remainingTime) 시간치"
+        homeChildView.remainingTimeLabel.text = "\(remainingTime) 시간치"
     }
     
 }

--- a/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
@@ -6,13 +6,14 @@
 //
 
 import UIKit
+import XLPagerTabStrip
 
 public class HomeChildViewController: UIViewController {
     
     // MARK: - Instance Properties
-    public var homeView: HomeView! {
+    public var homeView: HomeChildView! {
         guard isViewLoaded else { return nil }
-        return (view as! HomeView)
+        return (view as! HomeChildView)
     }
     
     // MARK: - View Lifecycle
@@ -75,5 +76,11 @@ extension HomeChildViewController: UICollectionViewDelegate, UICollectionViewDat
     
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: self.view.bounds.width, height: self.view.bounds.height / 6)
+    }
+}
+
+extension HomeChildViewController: IndicatorInfoProvider {
+    public func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        return "TEST"
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
@@ -1,5 +1,5 @@
 //
-//  HomeViewController.swift
+//  HomeChildViewController.swift
 //  CapstoneProject
 //
 //  Created by 김승찬 on 2022/05/08.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public class HomeViewController: UIViewController {
+public class HomeChildViewController: UIViewController {
     
     // MARK: - Instance Properties
     public var homeView: HomeView! {
@@ -57,7 +57,7 @@ public class HomeViewController: UIViewController {
 // cell 당 마진, 크기 조절
 // cell 터치 시에 효과 구현
 // cell 드래그 앤 드롭 구현
-extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+extension HomeChildViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 10

--- a/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeChildViewController.swift
@@ -24,7 +24,6 @@ public class HomeChildViewController: UIViewController {
         homeView.taskCollectionView.dataSource = self
         
         setupRemainingLabels()
-        setupAddTaskButton()
     }
     
     private func setupRemainingLabels() {
@@ -32,26 +31,6 @@ public class HomeChildViewController: UIViewController {
         homeView.remainingTimeLabel.text = "\(remainingTime) 시간치"
     }
     
-    private func setupAddTaskButton() {
-        // TO-DO
-        // Task detailView 만들기
-        let action = UIAction { _ in
-            guard let addTaskViewController = self.storyboard?.instantiateViewController(withIdentifier: "addTaskViewController") as? AddTaskViewController else { return }
-            // 화면 전환 애니메이션 설정
-            addTaskViewController.modalTransitionStyle = .coverVertical
-            // 전환된 화면이 보여지는 방법 설정 (fullScreen)
-            addTaskViewController.modalPresentationStyle = .fullScreen
-            self.present(addTaskViewController, animated: true, completion: nil)
-        }
-        // 커스텀 이미지 적용 후 pointSize 수정
-        let image = UIImage(systemName: "plus.circle.fill")
-        let pointSize: CGFloat = 40
-        
-        homeView.addTaskButton.setTitle("", for: .normal)
-        homeView.addTaskButton.addAction(action, for: .touchUpInside)
-        homeView.addTaskButton.setImage(image, for: .normal)
-        homeView.addTaskButton.setPreferredSymbolConfiguration(.init(pointSize: pointSize, weight: .regular), forImageIn: .normal)
-    }
 }
 
 // TO-DO

--- a/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
@@ -1,0 +1,23 @@
+//
+//  HomeParentViewController.swift
+//  CapstoneProject
+//
+//  Created by 김승찬 on 2022/05/16.
+//
+
+import UIKit
+import XLPagerTabStrip
+
+public class HomeParentViewController: ButtonBarPagerTabStripViewController {
+    // MARK: - View Lifecycle
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override public func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+        let child1 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "homeChildViewController")
+        let child2 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "homeChildViewController")
+        
+        return [child1, child2]
+    }
+}

--- a/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import XLPagerTabStrip
 
-public class HomeParentViewController: ButtonBarPagerTabStripViewController {
+public class HomeParentViewController: BarPagerTabStripViewController {
     
     // MARK: - Properties
     public var homeParentView: HomeParentView! {
@@ -20,10 +20,13 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
                                         "3일 뒤까지",
                                         "일주일 뒤까지"]
     
+    let remainingExpectedTimeLabels: [String] = ["3시간",
+                                                 "5시간",
+                                                 "7시간"]
+    
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
-        self.settings.style.buttonBarItemLeftRightMargin = (self.view.frame.width / 2)
-        self.settings.style.buttonBarItemsShouldFillAvailableWidth = false
+        self.settings.style.selectedBarBackgroundColor = UIColor.black
         super.viewDidLoad()
         setupAddTaskButton()
         
@@ -62,6 +65,7 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
         super.updateIndicator(for: viewController, fromIndex: fromIndex, toIndex: toIndex, withProgressPercentage: progressPercentage, indexWasChanged: indexWasChanged)
         if progressPercentage == 1, toIndex >= 0 && toIndex < remainingDayLabels.count {
             self.homeParentView.remainingDayLabel.text = self.remainingDayLabels[toIndex]
+            self.homeParentView.remainingTotalExpectedHourLabel.text = self.remainingExpectedTimeLabels[toIndex]
         }
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
@@ -16,19 +16,25 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
         return (view as! HomeParentView)
     }
     
+    let remainingDayLabels: [String] = ["내일까지",
+                                        "3일 뒤까지",
+                                        "일주일 뒤까지"]
+    
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
-        self.settings.style.buttonBarItemLeftRightMargin = (self.view.frame.width / 2 - 50)
+        self.settings.style.buttonBarItemLeftRightMargin = (self.view.frame.width / 2 - 100)
         self.settings.style.buttonBarItemsShouldFillAvailableWidth = false
         super.viewDidLoad()
         setupAddTaskButton()
+        
     }
     
     override public func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
-        let child1 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "homeChildViewController")
-        let child2 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "homeChildViewController")
+        let child1 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: TomorrowChildViewController.identifier)
+        let child2 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: ThreeDaysChildViewController.identifier)
+        let child3 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: ThreeDaysChildViewController.identifier)
         
-        return [child1, child2]
+        return [child1, child2, child3]
     }
     
     private func setupAddTaskButton() {
@@ -50,5 +56,10 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
         homeParentView.addTaskButton.addAction(action, for: .touchUpInside)
         homeParentView.addTaskButton.setImage(image, for: .normal)
         homeParentView.addTaskButton.setPreferredSymbolConfiguration(.init(pointSize: pointSize, weight: .regular), forImageIn: .normal)
+    }
+    
+    override public func updateIndicator(for viewController: PagerTabStripViewController, fromIndex: Int, toIndex: Int, withProgressPercentage progressPercentage: CGFloat, indexWasChanged: Bool) {
+        super.updateIndicator(for: viewController, fromIndex: fromIndex, toIndex: toIndex, withProgressPercentage: progressPercentage, indexWasChanged: indexWasChanged)
+        self.homeParentView.remainingDayLabel.text = self.remainingDayLabels[toIndex]
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
@@ -11,10 +11,15 @@ import XLPagerTabStrip
 public class HomeParentViewController: ButtonBarPagerTabStripViewController {
     
     // MARK: - Properties
-    @IBOutlet var addTaskButton: UIButton!
+    public var homeParentView: HomeParentView! {
+        guard isViewLoaded else { return nil }
+        return (view as! HomeParentView)
+    }
     
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
+        self.settings.style.buttonBarItemLeftRightMargin = (self.view.frame.width / 2 - 50)
+        self.settings.style.buttonBarItemsShouldFillAvailableWidth = false
         super.viewDidLoad()
         setupAddTaskButton()
     }
@@ -41,9 +46,9 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
         let image = UIImage(systemName: "plus.circle.fill")
         let pointSize: CGFloat = 40
         
-        self.addTaskButton.setTitle("", for: .normal)
-        self.addTaskButton.addAction(action, for: .touchUpInside)
-        self.addTaskButton.setImage(image, for: .normal)
-        self.addTaskButton.setPreferredSymbolConfiguration(.init(pointSize: pointSize, weight: .regular), forImageIn: .normal)
+        homeParentView.addTaskButton.setTitle("", for: .normal)
+        homeParentView.addTaskButton.addAction(action, for: .touchUpInside)
+        homeParentView.addTaskButton.setImage(image, for: .normal)
+        homeParentView.addTaskButton.setPreferredSymbolConfiguration(.init(pointSize: pointSize, weight: .regular), forImageIn: .normal)
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
@@ -24,6 +24,10 @@ public class HomeParentViewController: BarPagerTabStripViewController {
                                                  "5시간",
                                                  "7시간"]
     
+    let nextTabDayLabels: [String] = ["3일 뒤까지",
+                                      "일주일 뒤까지",
+                                      ""]
+    
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
         self.settings.style.selectedBarBackgroundColor = UIColor.black
@@ -66,6 +70,7 @@ public class HomeParentViewController: BarPagerTabStripViewController {
         if progressPercentage == 1, toIndex >= 0 && toIndex < remainingDayLabels.count {
             self.homeParentView.remainingDayLabel.text = self.remainingDayLabels[toIndex]
             self.homeParentView.remainingTotalExpectedHourLabel.text = self.remainingExpectedTimeLabels[toIndex]
+            self.homeParentView.nextTabDayLabel.text = self.nextTabDayLabels[toIndex]
         }
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
@@ -9,9 +9,14 @@ import UIKit
 import XLPagerTabStrip
 
 public class HomeParentViewController: ButtonBarPagerTabStripViewController {
+    
+    // MARK: - Properties
+    @IBOutlet var addTaskButton: UIButton!
+    
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
         super.viewDidLoad()
+        setupAddTaskButton()
     }
     
     override public func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
@@ -19,5 +24,26 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
         let child2 = UIStoryboard.init(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "homeChildViewController")
         
         return [child1, child2]
+    }
+    
+    private func setupAddTaskButton() {
+        // TO-DO
+        // Task detailView 만들기
+        let action = UIAction { _ in
+            guard let addTaskViewController = self.storyboard?.instantiateViewController(withIdentifier: "addTaskViewController") as? AddTaskViewController else { return }
+            // 화면 전환 애니메이션 설정
+            addTaskViewController.modalTransitionStyle = .coverVertical
+            // 전환된 화면이 보여지는 방법 설정 (fullScreen)
+            addTaskViewController.modalPresentationStyle = .fullScreen
+            self.present(addTaskViewController, animated: true, completion: nil)
+        }
+        // 커스텀 이미지 적용 후 pointSize 수정
+        let image = UIImage(systemName: "plus.circle.fill")
+        let pointSize: CGFloat = 40
+        
+        self.addTaskButton.setTitle("", for: .normal)
+        self.addTaskButton.addAction(action, for: .touchUpInside)
+        self.addTaskButton.setImage(image, for: .normal)
+        self.addTaskButton.setPreferredSymbolConfiguration(.init(pointSize: pointSize, weight: .regular), forImageIn: .normal)
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/HomeParentViewController.swift
@@ -22,7 +22,7 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
     
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
-        self.settings.style.buttonBarItemLeftRightMargin = (self.view.frame.width / 2 - 100)
+        self.settings.style.buttonBarItemLeftRightMargin = (self.view.frame.width / 2)
         self.settings.style.buttonBarItemsShouldFillAvailableWidth = false
         super.viewDidLoad()
         setupAddTaskButton()
@@ -60,6 +60,8 @@ public class HomeParentViewController: ButtonBarPagerTabStripViewController {
     
     override public func updateIndicator(for viewController: PagerTabStripViewController, fromIndex: Int, toIndex: Int, withProgressPercentage progressPercentage: CGFloat, indexWasChanged: Bool) {
         super.updateIndicator(for: viewController, fromIndex: fromIndex, toIndex: toIndex, withProgressPercentage: progressPercentage, indexWasChanged: indexWasChanged)
-        self.homeParentView.remainingDayLabel.text = self.remainingDayLabels[toIndex]
+        if progressPercentage == 1, toIndex >= 0 && toIndex < remainingDayLabels.count {
+            self.homeParentView.remainingDayLabel.text = self.remainingDayLabels[toIndex]
+        }
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/ThreeDaysChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/ThreeDaysChildViewController.swift
@@ -54,7 +54,7 @@ extension ThreeDaysChildViewController: UICollectionViewDelegate, UICollectionVi
 
 extension ThreeDaysChildViewController: IndicatorInfoProvider {
     public func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
-        return "10시간치 남았다."
+        return "20시간치 남았다."
     }
 }
 

--- a/CapstoneProject/CapstoneProject/Controllers/ThreeDaysChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/ThreeDaysChildViewController.swift
@@ -1,14 +1,16 @@
 //
-//  HomeChildViewController.swift
+//  ThreeDaysViewController.swift
 //  CapstoneProject
 //
-//  Created by 김승찬 on 2022/05/08.
+//  Created by 김승찬 on 2022/05/20.
 //
 
 import UIKit
 import XLPagerTabStrip
 
-public class HomeChildViewController: UIViewController {
+public class ThreeDaysChildViewController: UIViewController {
+    
+    static let identifier: String = "threeDaysChildViewController"
     
     // MARK: - Instance Properties
     public var homeChildView: HomeChildView! {
@@ -22,22 +24,14 @@ public class HomeChildViewController: UIViewController {
         
         homeChildView.taskCollectionView.delegate = self
         homeChildView.taskCollectionView.dataSource = self
-        
-        setupRemainingLabels()
     }
-    
-    private func setupRemainingLabels() {
-        let remainingTime: Int = 10
-        homeChildView.remainingTimeLabel.text = "\(remainingTime) 시간치"
-    }
-    
 }
 
 // TO-DO
 // cell 당 마진, 크기 조절
 // cell 터치 시에 효과 구현
 // cell 드래그 앤 드롭 구현
-extension HomeChildViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+extension ThreeDaysChildViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 10
@@ -47,7 +41,7 @@ extension HomeChildViewController: UICollectionViewDelegate, UICollectionViewDat
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeTaskCell.identifier, for: indexPath) as! HomeTaskCell
        
         cell.taskNameLabel.text = "Example Task"
-        cell.taskExpectedTimeLabel.text = "O 시간"
+        cell.taskExpectedTimeLabel.text = "1O 시간"
         
         
         return cell
@@ -58,8 +52,9 @@ extension HomeChildViewController: UICollectionViewDelegate, UICollectionViewDat
     }
 }
 
-extension HomeChildViewController: IndicatorInfoProvider {
+extension ThreeDaysChildViewController: IndicatorInfoProvider {
     public func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
-        return "TEST"
+        return "10시간치 남았다."
     }
 }
+

--- a/CapstoneProject/CapstoneProject/Controllers/TomorrowChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/TomorrowChildViewController.swift
@@ -34,7 +34,7 @@ public class TomorrowChildViewController: UIViewController {
 extension TomorrowChildViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
+        return 3
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/CapstoneProject/CapstoneProject/Controllers/TomorrowChildViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/TomorrowChildViewController.swift
@@ -1,0 +1,59 @@
+//
+//  HomeChildViewController.swift
+//  CapstoneProject
+//
+//  Created by 김승찬 on 2022/05/08.
+//
+
+import UIKit
+import XLPagerTabStrip
+
+public class TomorrowChildViewController: UIViewController {
+    
+    static let identifier: String = "tomorrowChildViewController"
+    
+    // MARK: - Instance Properties
+    public var homeChildView: HomeChildView! {
+        guard isViewLoaded else { return nil }
+        return (view as! HomeChildView)
+    }
+    
+    // MARK: - View Lifecycle
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        homeChildView.taskCollectionView.delegate = self
+        homeChildView.taskCollectionView.dataSource = self
+    }
+}
+
+// TO-DO
+// cell 당 마진, 크기 조절
+// cell 터치 시에 효과 구현
+// cell 드래그 앤 드롭 구현
+extension TomorrowChildViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 10
+    }
+    
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeTaskCell.identifier, for: indexPath) as! HomeTaskCell
+       
+        cell.taskNameLabel.text = "Example Task"
+        cell.taskExpectedTimeLabel.text = "O 시간"
+        
+        
+        return cell
+    }
+    
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: self.view.bounds.width, height: self.view.bounds.height / 6)
+    }
+}
+
+extension TomorrowChildViewController: IndicatorInfoProvider {
+    public func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        return "10시간치 남았다."
+    }
+}

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -12,36 +12,43 @@
         <!--Home Parent View Controller-->
         <scene sceneID="SnM-kb-foF">
             <objects>
-                <viewController id="xK7-dH-N53" customClass="HomeParentViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="homeParentViewController" id="xK7-dH-N53" customClass="HomeParentViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YnQ-HN-2gj" customClass="HomeParentView" customModule="CapstoneProject" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="내일까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="95U-3m-zpm">
+                                <rect key="frame" x="30" y="40" width="122" height="42"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2p8-9T-bOw" customClass="ButtonBarView" customModule="XLPagerTabStrip">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
+                                <rect key="frame" x="0.0" y="92" width="375" height="100"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="200" id="DyU-6k-Y7a"/>
+                                    <constraint firstAttribute="height" constant="100" id="DyU-6k-Y7a"/>
                                 </constraints>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="lGp-QF-87u">
-                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="itemSize" width="100" height="100"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="6Of-Hq-pbt">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="nh2-Am-chs">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </collectionViewCellContentView>
+                                        <size key="customSize" width="100" height="100"/>
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCi-yI-ELp">
-                                <rect key="frame" x="0.0" y="208" width="375" height="459"/>
+                                <rect key="frame" x="0.0" y="200" width="375" height="467"/>
                                 <viewLayoutGuide key="contentLayoutGuide" id="v5d-0n-Gn0"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="v5f-K1-ftC"/>
                             </scrollView>
@@ -59,17 +66,20 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="fCi-yI-ELp" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="06G-lt-eP4"/>
-                            <constraint firstItem="2p8-9T-bOw" firstAttribute="top" secondItem="qdD-oX-Emq" secondAttribute="top" id="4R5-dM-94q"/>
+                            <constraint firstItem="95U-3m-zpm" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" constant="30" id="1xf-ej-pIq"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="fCi-yI-ELp" secondAttribute="trailing" id="6cW-21-3pU"/>
+                            <constraint firstItem="95U-3m-zpm" firstAttribute="top" secondItem="qdD-oX-Emq" secondAttribute="top" constant="40" id="7sZ-K9-9Sg"/>
                             <constraint firstItem="fCi-yI-ELp" firstAttribute="top" secondItem="2p8-9T-bOw" secondAttribute="bottom" id="GFv-Vd-Kye"/>
                             <constraint firstItem="2p8-9T-bOw" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="Iht-6g-6gs"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="fCi-yI-ELp" secondAttribute="bottom" id="MzC-4b-7w5"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="nzP-Wy-2Cc" secondAttribute="trailing" constant="30" id="PPZ-N3-JLq"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="2p8-9T-bOw" secondAttribute="trailing" id="bdD-xc-wxx"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="nzP-Wy-2Cc" secondAttribute="bottom" constant="30" id="toy-ia-aog"/>
+                            <constraint firstItem="2p8-9T-bOw" firstAttribute="top" secondItem="95U-3m-zpm" secondAttribute="bottom" constant="10" id="uoP-Ud-IQK"/>
                         </constraints>
                         <connections>
                             <outlet property="addTaskButton" destination="nzP-Wy-2Cc" id="jk8-KU-zYr"/>
+                            <outlet property="remainingDayLabel" destination="95U-3m-zpm" id="MFE-Mf-Ec9"/>
                         </connections>
                     </view>
                     <connections>
@@ -79,127 +89,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qph-SB-rtd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1393" y="108"/>
-        </scene>
-        <!--Home Child View Controller-->
-        <scene sceneID="tne-QT-ifu">
-            <objects>
-                <viewController storyboardIdentifier="homeChildViewController" id="BYZ-38-t0r" customClass="HomeChildViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="HomeChildView" customModule="CapstoneProject" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="내일까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lEE-MY-vKC">
-                                <rect key="frame" x="30" y="40" width="122" height="42"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="O 시간치" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aEW-xn-pU5">
-                                <rect key="frame" x="30" y="92" width="125" height="42"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="남았다" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JmG-xk-gPy">
-                                <rect key="frame" x="175" y="104" width="65" height="30"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="RPT-NP-yvq">
-                                <rect key="frame" x="0.0" y="154" width="375" height="513"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="RrA-3E-r27">
-                                    <size key="itemSize" width="368" height="128"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="homeTaskCell" id="muR-kM-fVE" customClass="HomeTaskCell" customModule="CapstoneProject" customModuleProvider="target">
-                                        <rect key="frame" x="3.5" y="0.0" width="368" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ZpF-NW-dp3">
-                                            <rect key="frame" x="0.0" y="0.0" width="368" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KmM-oM-cLL">
-                                                    <rect key="frame" x="15" y="5" width="3" height="118"/>
-                                                    <color key="backgroundColor" red="0.91897267100000002" green="0.2517300844" blue="0.14302992819999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="3" id="qWh-nL-a5Z"/>
-                                                    </constraints>
-                                                </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="캡스톤 앱 구현" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FWD-xs-3LE">
-                                                    <rect key="frame" x="45" y="8" width="97" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="X9C-gP-HNA">
-                                                    <rect key="frame" x="45" y="85" width="240" height="35"/>
-                                                    <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="35" id="ZlY-BL-KjH"/>
-                                                        <constraint firstAttribute="width" constant="240" id="rE0-eh-XZC"/>
-                                                    </constraints>
-                                                </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kmT-xh-0dX">
-                                                    <rect key="frame" x="45" y="38.5" width="40.5" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="FWD-xs-3LE" firstAttribute="leading" secondItem="KmM-oM-cLL" secondAttribute="leading" constant="30" id="3LV-YG-qLZ"/>
-                                                <constraint firstAttribute="bottom" secondItem="KmM-oM-cLL" secondAttribute="bottom" constant="5" id="3yr-eK-J0m"/>
-                                                <constraint firstItem="FWD-xs-3LE" firstAttribute="top" secondItem="KmM-oM-cLL" secondAttribute="top" constant="3" id="7Zi-Ip-Pua"/>
-                                                <constraint firstItem="X9C-gP-HNA" firstAttribute="leading" secondItem="FWD-xs-3LE" secondAttribute="leading" id="E75-Pr-e0O"/>
-                                                <constraint firstItem="KmM-oM-cLL" firstAttribute="top" secondItem="ZpF-NW-dp3" secondAttribute="top" constant="5" id="KL9-Aa-y65"/>
-                                                <constraint firstItem="X9C-gP-HNA" firstAttribute="bottom" secondItem="KmM-oM-cLL" secondAttribute="bottom" constant="-3" id="MaP-oD-KdL"/>
-                                                <constraint firstItem="kmT-xh-0dX" firstAttribute="leading" secondItem="FWD-xs-3LE" secondAttribute="leading" id="SJ4-qp-LrI"/>
-                                                <constraint firstItem="kmT-xh-0dX" firstAttribute="top" secondItem="FWD-xs-3LE" secondAttribute="bottom" constant="10" id="rQU-SB-nRw"/>
-                                                <constraint firstItem="KmM-oM-cLL" firstAttribute="leading" secondItem="ZpF-NW-dp3" secondAttribute="leading" constant="15" id="vCm-cp-Y5a"/>
-                                            </constraints>
-                                        </collectionViewCellContentView>
-                                        <size key="customSize" width="368" height="128"/>
-                                        <connections>
-                                            <outlet property="categoryColorBar" destination="KmM-oM-cLL" id="4vX-YY-bzz"/>
-                                            <outlet property="taskBar" destination="X9C-gP-HNA" id="Upe-9m-DNF"/>
-                                            <outlet property="taskExpectedTimeLabel" destination="kmT-xh-0dX" id="LlL-jL-5W1"/>
-                                            <outlet property="taskNameLabel" destination="FWD-xs-3LE" id="XYl-fu-J2B"/>
-                                        </connections>
-                                    </collectionViewCell>
-                                </cells>
-                            </collectionView>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="RPT-NP-yvq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="6aU-jV-LZv"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="RPT-NP-yvq" secondAttribute="trailing" id="Kov-UT-3jp"/>
-                            <constraint firstItem="lEE-MY-vKC" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="40" id="OQQ-Uk-nm9"/>
-                            <constraint firstItem="lEE-MY-vKC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="bvD-zT-R9b"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="RPT-NP-yvq" secondAttribute="bottom" id="dGY-T5-XoN"/>
-                            <constraint firstItem="aEW-xn-pU5" firstAttribute="leading" secondItem="lEE-MY-vKC" secondAttribute="leading" id="gQq-gV-8Cd"/>
-                            <constraint firstItem="RPT-NP-yvq" firstAttribute="top" secondItem="aEW-xn-pU5" secondAttribute="bottom" constant="20" id="hlX-wK-Hmi"/>
-                            <constraint firstItem="JmG-xk-gPy" firstAttribute="bottom" secondItem="aEW-xn-pU5" secondAttribute="bottom" id="lgJ-qV-1e6"/>
-                            <constraint firstItem="aEW-xn-pU5" firstAttribute="top" secondItem="lEE-MY-vKC" secondAttribute="bottom" constant="10" id="qP5-li-ouu"/>
-                            <constraint firstItem="JmG-xk-gPy" firstAttribute="leading" secondItem="aEW-xn-pU5" secondAttribute="trailing" constant="20" id="yie-6b-rjU"/>
-                        </constraints>
-                        <connections>
-                            <outlet property="remainingTextLabel" destination="JmG-xk-gPy" id="8gw-aZ-f8H"/>
-                            <outlet property="remainingTimeLabel" destination="aEW-xn-pU5" id="PLj-DD-rjQ"/>
-                            <outlet property="taskCollectionView" destination="RPT-NP-yvq" id="QeD-Ol-U9i"/>
-                            <outlet property="tomorrowTextLabel" destination="lEE-MY-vKC" id="2cb-Kw-hwg"/>
-                        </connections>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-482" y="-224"/>
+            <point key="canvasLocation" x="-1394.4000000000001" y="107.49625187406298"/>
         </scene>
         <!--Add Task View Controller-->
         <scene sceneID="GZr-n4-THi">
@@ -373,6 +263,192 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jAF-6p-amF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="876" y="109"/>
+        </scene>
+        <!--Tomorrow Child View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController storyboardIdentifier="tomorrowChildViewController" id="BYZ-38-t0r" customClass="TomorrowChildViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="HomeChildView" customModule="CapstoneProject" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="RPT-NP-yvq">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="RrA-3E-r27">
+                                    <size key="itemSize" width="368" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="homeTaskCell" id="muR-kM-fVE" customClass="HomeTaskCell" customModule="CapstoneProject" customModuleProvider="target">
+                                        <rect key="frame" x="3.5" y="0.0" width="368" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ZpF-NW-dp3">
+                                            <rect key="frame" x="0.0" y="0.0" width="368" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KmM-oM-cLL">
+                                                    <rect key="frame" x="15" y="5" width="3" height="118"/>
+                                                    <color key="backgroundColor" red="0.91897267100000002" green="0.2517300844" blue="0.14302992819999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="3" id="qWh-nL-a5Z"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="캡스톤 앱 구현" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FWD-xs-3LE">
+                                                    <rect key="frame" x="45" y="8" width="97" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="X9C-gP-HNA">
+                                                    <rect key="frame" x="45" y="85" width="240" height="35"/>
+                                                    <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="35" id="ZlY-BL-KjH"/>
+                                                        <constraint firstAttribute="width" constant="240" id="rE0-eh-XZC"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kmT-xh-0dX">
+                                                    <rect key="frame" x="45" y="38.5" width="40.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="FWD-xs-3LE" firstAttribute="leading" secondItem="KmM-oM-cLL" secondAttribute="leading" constant="30" id="3LV-YG-qLZ"/>
+                                                <constraint firstAttribute="bottom" secondItem="KmM-oM-cLL" secondAttribute="bottom" constant="5" id="3yr-eK-J0m"/>
+                                                <constraint firstItem="FWD-xs-3LE" firstAttribute="top" secondItem="KmM-oM-cLL" secondAttribute="top" constant="3" id="7Zi-Ip-Pua"/>
+                                                <constraint firstItem="X9C-gP-HNA" firstAttribute="leading" secondItem="FWD-xs-3LE" secondAttribute="leading" id="E75-Pr-e0O"/>
+                                                <constraint firstItem="KmM-oM-cLL" firstAttribute="top" secondItem="ZpF-NW-dp3" secondAttribute="top" constant="5" id="KL9-Aa-y65"/>
+                                                <constraint firstItem="X9C-gP-HNA" firstAttribute="bottom" secondItem="KmM-oM-cLL" secondAttribute="bottom" constant="-3" id="MaP-oD-KdL"/>
+                                                <constraint firstItem="kmT-xh-0dX" firstAttribute="leading" secondItem="FWD-xs-3LE" secondAttribute="leading" id="SJ4-qp-LrI"/>
+                                                <constraint firstItem="kmT-xh-0dX" firstAttribute="top" secondItem="FWD-xs-3LE" secondAttribute="bottom" constant="10" id="rQU-SB-nRw"/>
+                                                <constraint firstItem="KmM-oM-cLL" firstAttribute="leading" secondItem="ZpF-NW-dp3" secondAttribute="leading" constant="15" id="vCm-cp-Y5a"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="368" height="128"/>
+                                        <connections>
+                                            <outlet property="categoryColorBar" destination="KmM-oM-cLL" id="4vX-YY-bzz"/>
+                                            <outlet property="taskBar" destination="X9C-gP-HNA" id="Upe-9m-DNF"/>
+                                            <outlet property="taskExpectedTimeLabel" destination="kmT-xh-0dX" id="LlL-jL-5W1"/>
+                                            <outlet property="taskNameLabel" destination="FWD-xs-3LE" id="XYl-fu-J2B"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="RPT-NP-yvq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="6aU-jV-LZv"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="RPT-NP-yvq" secondAttribute="trailing" id="Kov-UT-3jp"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="RPT-NP-yvq" secondAttribute="bottom" id="dGY-T5-XoN"/>
+                            <constraint firstItem="RPT-NP-yvq" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="f0s-I7-SxR"/>
+                        </constraints>
+                        <connections>
+                            <outlet property="taskCollectionView" destination="RPT-NP-yvq" id="QeD-Ol-U9i"/>
+                        </connections>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-482" y="-224"/>
+        </scene>
+        <!--Three Days Child View Controller-->
+        <scene sceneID="4Oj-js-G2i">
+            <objects>
+                <viewController storyboardIdentifier="threeDaysChildViewController" id="w11-Rk-CV6" customClass="ThreeDaysChildViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="QPw-Sd-iZF" customClass="HomeChildView" customModule="CapstoneProject" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Nko-7J-paL">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="IRn-Ju-Gfv">
+                                    <size key="itemSize" width="368" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="homeTaskCell" id="GCz-ya-87N" customClass="HomeTaskCell" customModule="CapstoneProject" customModuleProvider="target">
+                                        <rect key="frame" x="3.5" y="0.0" width="368" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="2xS-3G-ffj">
+                                            <rect key="frame" x="0.0" y="0.0" width="368" height="128"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1Z2-7e-iEP">
+                                                    <rect key="frame" x="15" y="5" width="3" height="118"/>
+                                                    <color key="backgroundColor" red="0.91897267100000002" green="0.2517300844" blue="0.14302992819999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="3" id="BQu-x6-jok"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="캡스톤 앱 구현" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2UK-iA-BYX">
+                                                    <rect key="frame" x="45" y="8" width="97" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Rdb-hw-zLC">
+                                                    <rect key="frame" x="45" y="85" width="240" height="35"/>
+                                                    <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="240" id="AND-XD-fyh"/>
+                                                        <constraint firstAttribute="height" constant="35" id="BFF-vt-aYT"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pcO-gg-1kv">
+                                                    <rect key="frame" x="45" y="38.5" width="40.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="2UK-iA-BYX" firstAttribute="leading" secondItem="1Z2-7e-iEP" secondAttribute="leading" constant="30" id="AYI-ht-dm2"/>
+                                                <constraint firstItem="2UK-iA-BYX" firstAttribute="top" secondItem="1Z2-7e-iEP" secondAttribute="top" constant="3" id="KdX-yY-zTp"/>
+                                                <constraint firstItem="1Z2-7e-iEP" firstAttribute="top" secondItem="2xS-3G-ffj" secondAttribute="top" constant="5" id="Kz5-nd-sFY"/>
+                                                <constraint firstItem="pcO-gg-1kv" firstAttribute="leading" secondItem="2UK-iA-BYX" secondAttribute="leading" id="SlE-x4-a9Y"/>
+                                                <constraint firstItem="Rdb-hw-zLC" firstAttribute="bottom" secondItem="1Z2-7e-iEP" secondAttribute="bottom" constant="-3" id="Vnh-Ph-R4J"/>
+                                                <constraint firstItem="Rdb-hw-zLC" firstAttribute="leading" secondItem="2UK-iA-BYX" secondAttribute="leading" id="YxX-Mj-44G"/>
+                                                <constraint firstItem="1Z2-7e-iEP" firstAttribute="leading" secondItem="2xS-3G-ffj" secondAttribute="leading" constant="15" id="e0N-Gx-3PP"/>
+                                                <constraint firstAttribute="bottom" secondItem="1Z2-7e-iEP" secondAttribute="bottom" constant="5" id="hd9-4v-rsh"/>
+                                                <constraint firstItem="pcO-gg-1kv" firstAttribute="top" secondItem="2UK-iA-BYX" secondAttribute="bottom" constant="10" id="hw9-Y0-sub"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="368" height="128"/>
+                                        <connections>
+                                            <outlet property="categoryColorBar" destination="1Z2-7e-iEP" id="gRt-yi-e7y"/>
+                                            <outlet property="taskBar" destination="Rdb-hw-zLC" id="Eig-L7-Obl"/>
+                                            <outlet property="taskExpectedTimeLabel" destination="pcO-gg-1kv" id="cto-HP-v5S"/>
+                                            <outlet property="taskNameLabel" destination="2UK-iA-BYX" id="VP5-uO-H9S"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="pzN-MU-NID"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Nko-7J-paL" firstAttribute="leading" secondItem="pzN-MU-NID" secondAttribute="leading" id="9Fn-4j-AqF"/>
+                            <constraint firstItem="Nko-7J-paL" firstAttribute="top" secondItem="pzN-MU-NID" secondAttribute="top" constant="20" id="Vsx-rj-Dln"/>
+                            <constraint firstItem="pzN-MU-NID" firstAttribute="bottom" secondItem="Nko-7J-paL" secondAttribute="bottom" id="cWA-KE-4C5"/>
+                            <constraint firstItem="pzN-MU-NID" firstAttribute="trailing" secondItem="Nko-7J-paL" secondAttribute="trailing" id="jZg-ij-y7j"/>
+                        </constraints>
+                        <connections>
+                            <outlet property="taskCollectionView" destination="Nko-7J-paL" id="b33-ih-QBc"/>
+                        </connections>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="p6E-8J-rHI" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-482" y="512"/>
         </scene>
     </scenes>
     <resources>

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xK7-dH-N53">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -9,11 +9,69 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Home View Controller-->
+        <!--Home Parent View Controller-->
+        <scene sceneID="SnM-kb-foF">
+            <objects>
+                <viewController id="xK7-dH-N53" customClass="HomeParentViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="YnQ-HN-2gj">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2p8-9T-bOw" customClass="ButtonBarView" customModule="XLPagerTabStrip">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="DyU-6k-Y7a"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="lGp-QF-87u">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="6Of-Hq-pbt">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="nh2-Am-chs">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCi-yI-ELp">
+                                <rect key="frame" x="0.0" y="208" width="375" height="459"/>
+                                <viewLayoutGuide key="contentLayoutGuide" id="v5d-0n-Gn0"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="v5f-K1-ftC"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="qdD-oX-Emq"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="fCi-yI-ELp" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="06G-lt-eP4"/>
+                            <constraint firstItem="2p8-9T-bOw" firstAttribute="top" secondItem="qdD-oX-Emq" secondAttribute="top" id="4R5-dM-94q"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="fCi-yI-ELp" secondAttribute="trailing" id="6cW-21-3pU"/>
+                            <constraint firstItem="fCi-yI-ELp" firstAttribute="top" secondItem="2p8-9T-bOw" secondAttribute="bottom" id="GFv-Vd-Kye"/>
+                            <constraint firstItem="2p8-9T-bOw" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="Iht-6g-6gs"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="fCi-yI-ELp" secondAttribute="bottom" id="MzC-4b-7w5"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="2p8-9T-bOw" secondAttribute="trailing" id="bdD-xc-wxx"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="buttonBarView" destination="2p8-9T-bOw" id="Zuq-bS-Rss"/>
+                        <outlet property="containerView" destination="fCi-yI-ELp" id="hpE-6M-raG"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Qph-SB-rtd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-612" y="108.39580209895054"/>
+        </scene>
+        <!--Home Child View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="HomeViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="HomeView" customModule="CapstoneProject" customModuleProvider="target">
+                <viewController storyboardIdentifier="homeChildViewController" id="BYZ-38-t0r" customClass="HomeChildViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="HomeChildView" customModule="CapstoneProject" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -129,11 +187,11 @@
                             <constraint firstItem="JmG-xk-gPy" firstAttribute="leading" secondItem="aEW-xn-pU5" secondAttribute="trailing" constant="20" id="yie-6b-rjU"/>
                         </constraints>
                         <connections>
-                            <outlet property="addTaskButton" destination="ejJ-c7-Zgb" id="Q3Y-eB-qs6"/>
-                            <outlet property="remainingTextLabel" destination="JmG-xk-gPy" id="kr8-4C-LoW"/>
-                            <outlet property="remainingTimeLabel" destination="aEW-xn-pU5" id="jUc-TX-j6N"/>
-                            <outlet property="taskCollectionView" destination="RPT-NP-yvq" id="G2e-28-tAh"/>
-                            <outlet property="tomorrowTextLabel" destination="lEE-MY-vKC" id="WYL-Nf-eiW"/>
+                            <outlet property="addTaskButton" destination="ejJ-c7-Zgb" id="a4V-4j-uTC"/>
+                            <outlet property="remainingTextLabel" destination="JmG-xk-gPy" id="8gw-aZ-f8H"/>
+                            <outlet property="remainingTimeLabel" destination="aEW-xn-pU5" id="PLj-DD-rjQ"/>
+                            <outlet property="taskCollectionView" destination="RPT-NP-yvq" id="QeD-Ol-U9i"/>
+                            <outlet property="tomorrowTextLabel" destination="lEE-MY-vKC" id="2cb-Kw-hwg"/>
                         </connections>
                     </view>
                 </viewController>

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -47,11 +47,6 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCi-yI-ELp">
-                                <rect key="frame" x="0.0" y="200" width="375" height="467"/>
-                                <viewLayoutGuide key="contentLayoutGuide" id="v5d-0n-Gn0"/>
-                                <viewLayoutGuide key="frameLayoutGuide" id="v5f-K1-ftC"/>
-                            </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nzP-Wy-2Cc">
                                 <rect key="frame" x="245" y="537" width="100" height="100"/>
                                 <constraints>
@@ -61,21 +56,36 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gpQ-xy-9dg">
+                                <rect key="frame" x="0.0" y="192" width="375" height="475"/>
+                                <subviews>
+                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fCi-yI-ELp">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="475"/>
+                                    </scrollView>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="fCi-yI-ELp" firstAttribute="top" secondItem="gpQ-xy-9dg" secondAttribute="top" id="Eb4-gl-uGC"/>
+                                    <constraint firstItem="fCi-yI-ELp" firstAttribute="leading" secondItem="gpQ-xy-9dg" secondAttribute="leading" id="hLZ-Ad-tH5"/>
+                                    <constraint firstAttribute="trailing" secondItem="fCi-yI-ELp" secondAttribute="trailing" id="yIs-4n-Opy"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="qdD-oX-Emq"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="fCi-yI-ELp" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="06G-lt-eP4"/>
                             <constraint firstItem="95U-3m-zpm" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" constant="30" id="1xf-ej-pIq"/>
-                            <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="fCi-yI-ELp" secondAttribute="trailing" id="6cW-21-3pU"/>
                             <constraint firstItem="95U-3m-zpm" firstAttribute="top" secondItem="qdD-oX-Emq" secondAttribute="top" constant="40" id="7sZ-K9-9Sg"/>
-                            <constraint firstItem="fCi-yI-ELp" firstAttribute="top" secondItem="2p8-9T-bOw" secondAttribute="bottom" id="GFv-Vd-Kye"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="fCi-yI-ELp" secondAttribute="bottom" id="AUI-34-A8q"/>
                             <constraint firstItem="2p8-9T-bOw" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="Iht-6g-6gs"/>
-                            <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="fCi-yI-ELp" secondAttribute="bottom" id="MzC-4b-7w5"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="nzP-Wy-2Cc" secondAttribute="trailing" constant="30" id="PPZ-N3-JLq"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="gpQ-xy-9dg" secondAttribute="trailing" id="Rrq-f8-qbx"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="gpQ-xy-9dg" secondAttribute="bottom" id="YMc-6A-uHS"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="2p8-9T-bOw" secondAttribute="trailing" id="bdD-xc-wxx"/>
+                            <constraint firstItem="gpQ-xy-9dg" firstAttribute="top" secondItem="2p8-9T-bOw" secondAttribute="bottom" id="kGH-NN-1Vg"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="nzP-Wy-2Cc" secondAttribute="bottom" constant="30" id="toy-ia-aog"/>
                             <constraint firstItem="2p8-9T-bOw" firstAttribute="top" secondItem="95U-3m-zpm" secondAttribute="bottom" constant="10" id="uoP-Ud-IQK"/>
+                            <constraint firstItem="gpQ-xy-9dg" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="xfz-X3-xjv"/>
                         </constraints>
                         <connections>
                             <outlet property="addTaskButton" destination="nzP-Wy-2Cc" id="jk8-KU-zYr"/>

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <scene sceneID="SnM-kb-foF">
             <objects>
                 <viewController id="xK7-dH-N53" customClass="HomeParentViewController" customModule="CapstoneProject" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="YnQ-HN-2gj">
+                    <view key="view" contentMode="scaleToFill" id="YnQ-HN-2gj" customClass="HomeParentView" customModule="CapstoneProject" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -68,16 +68,18 @@
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="2p8-9T-bOw" secondAttribute="trailing" id="bdD-xc-wxx"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="nzP-Wy-2Cc" secondAttribute="bottom" constant="30" id="toy-ia-aog"/>
                         </constraints>
+                        <connections>
+                            <outlet property="addTaskButton" destination="nzP-Wy-2Cc" id="jk8-KU-zYr"/>
+                        </connections>
                     </view>
                     <connections>
-                        <outlet property="addTaskButton" destination="nzP-Wy-2Cc" id="mOr-QU-Dxv"/>
                         <outlet property="buttonBarView" destination="2p8-9T-bOw" id="Zuq-bS-Rss"/>
                         <outlet property="containerView" destination="fCi-yI-ELp" id="hpE-6M-raG"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qph-SB-rtd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-612" y="108.39580209895054"/>
+            <point key="canvasLocation" x="-1393" y="108"/>
         </scene>
         <!--Home Child View Controller-->
         <scene sceneID="tne-QT-ifu">
@@ -197,7 +199,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="138.40000000000001" y="109.29535232383809"/>
+            <point key="canvasLocation" x="-482" y="-224"/>
         </scene>
         <!--Add Task View Controller-->
         <scene sceneID="GZr-n4-THi">

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -23,44 +23,24 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2p8-9T-bOw" customClass="ButtonBarView" customModule="XLPagerTabStrip">
-                                <rect key="frame" x="0.0" y="92" width="375" height="100"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="O 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mRv-xN-2YE">
+                                <rect key="frame" x="30" y="92" width="95" height="42"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tX0-lD-oD9" customClass="BarView" customModule="XLPagerTabStrip">
+                                <rect key="frame" x="0.0" y="144" width="375" height="0.0"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="100" id="DyU-6k-Y7a"/>
+                                    <constraint firstAttribute="height" id="5y2-oY-HXF"/>
                                 </constraints>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="lGp-QF-87u">
-                                    <size key="itemSize" width="100" height="100"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="6Of-Hq-pbt">
-                                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="nh2-Am-chs">
-                                            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                        <size key="customSize" width="100" height="100"/>
-                                    </collectionViewCell>
-                                </cells>
-                            </collectionView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nzP-Wy-2Cc">
-                                <rect key="frame" x="245" y="537" width="100" height="100"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="nzP-Wy-2Cc" secondAttribute="height" multiplier="1:1" id="eHK-Mg-F9g"/>
-                                    <constraint firstAttribute="width" constant="100" id="zpm-DI-1u2"/>
-                                </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
-                            </button>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gpQ-xy-9dg">
-                                <rect key="frame" x="0.0" y="192" width="375" height="475"/>
+                                <rect key="frame" x="0.0" y="144" width="375" height="523"/>
                                 <subviews>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fCi-yI-ELp">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="475"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="523"/>
                                     </scrollView>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -70,30 +50,42 @@
                                     <constraint firstAttribute="trailing" secondItem="fCi-yI-ELp" secondAttribute="trailing" id="yIs-4n-Opy"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nzP-Wy-2Cc">
+                                <rect key="frame" x="245" y="537" width="100" height="100"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="nzP-Wy-2Cc" secondAttribute="height" multiplier="1:1" id="eHK-Mg-F9g"/>
+                                    <constraint firstAttribute="width" constant="100" id="zpm-DI-1u2"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="qdD-oX-Emq"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="95U-3m-zpm" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" constant="30" id="1xf-ej-pIq"/>
                             <constraint firstItem="95U-3m-zpm" firstAttribute="top" secondItem="qdD-oX-Emq" secondAttribute="top" constant="40" id="7sZ-K9-9Sg"/>
+                            <constraint firstItem="mRv-xN-2YE" firstAttribute="bottom" secondItem="tX0-lD-oD9" secondAttribute="top" constant="-10" id="A0V-7s-Y7P"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="fCi-yI-ELp" secondAttribute="bottom" id="AUI-34-A8q"/>
-                            <constraint firstItem="2p8-9T-bOw" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="Iht-6g-6gs"/>
+                            <constraint firstItem="mRv-xN-2YE" firstAttribute="top" secondItem="95U-3m-zpm" secondAttribute="bottom" constant="10" id="FtJ-cS-uLb"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="nzP-Wy-2Cc" secondAttribute="trailing" constant="30" id="PPZ-N3-JLq"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="gpQ-xy-9dg" secondAttribute="trailing" id="Rrq-f8-qbx"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="gpQ-xy-9dg" secondAttribute="bottom" id="YMc-6A-uHS"/>
-                            <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="2p8-9T-bOw" secondAttribute="trailing" id="bdD-xc-wxx"/>
-                            <constraint firstItem="gpQ-xy-9dg" firstAttribute="top" secondItem="2p8-9T-bOw" secondAttribute="bottom" id="kGH-NN-1Vg"/>
+                            <constraint firstItem="tX0-lD-oD9" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="njU-sa-YsX"/>
+                            <constraint firstItem="mRv-xN-2YE" firstAttribute="leading" secondItem="95U-3m-zpm" secondAttribute="leading" id="pwy-x2-V08"/>
+                            <constraint firstItem="tX0-lD-oD9" firstAttribute="bottom" secondItem="gpQ-xy-9dg" secondAttribute="top" id="teA-uX-w16"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="nzP-Wy-2Cc" secondAttribute="bottom" constant="30" id="toy-ia-aog"/>
-                            <constraint firstItem="2p8-9T-bOw" firstAttribute="top" secondItem="95U-3m-zpm" secondAttribute="bottom" constant="10" id="uoP-Ud-IQK"/>
                             <constraint firstItem="gpQ-xy-9dg" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="xfz-X3-xjv"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="tX0-lD-oD9" secondAttribute="trailing" id="zwW-Ie-Azk"/>
                         </constraints>
                         <connections>
                             <outlet property="addTaskButton" destination="nzP-Wy-2Cc" id="jk8-KU-zYr"/>
                             <outlet property="remainingDayLabel" destination="95U-3m-zpm" id="MFE-Mf-Ec9"/>
+                            <outlet property="remainingTotalExpectedHourLabel" destination="mRv-xN-2YE" id="tZj-Fn-Kmq"/>
                         </connections>
                     </view>
                     <connections>
-                        <outlet property="buttonBarView" destination="2p8-9T-bOw" id="Zuq-bS-Rss"/>
+                        <outlet property="barView" destination="tX0-lD-oD9" id="elT-Af-EzB"/>
                         <outlet property="containerView" destination="fCi-yI-ELp" id="hpE-6M-raG"/>
                     </connections>
                 </viewController>

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -29,6 +29,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="남았다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GUX-tX-BgN">
+                                <rect key="frame" x="140" y="95" width="85.5" height="36"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tX0-lD-oD9" customClass="BarView" customModule="XLPagerTabStrip">
                                 <rect key="frame" x="0.0" y="144" width="375" height="0.0"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -59,27 +65,38 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3일 뒤까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Un-lM-k1k">
+                                <rect key="frame" x="304" y="40" width="151" height="42"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
+                                <color key="textColor" systemColor="placeholderTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="qdD-oX-Emq"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="GUX-tX-BgN" firstAttribute="leading" secondItem="mRv-xN-2YE" secondAttribute="trailing" constant="15" id="1kq-OW-kX9"/>
                             <constraint firstItem="95U-3m-zpm" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" constant="30" id="1xf-ej-pIq"/>
                             <constraint firstItem="95U-3m-zpm" firstAttribute="top" secondItem="qdD-oX-Emq" secondAttribute="top" constant="40" id="7sZ-K9-9Sg"/>
                             <constraint firstItem="mRv-xN-2YE" firstAttribute="bottom" secondItem="tX0-lD-oD9" secondAttribute="top" constant="-10" id="A0V-7s-Y7P"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="fCi-yI-ELp" secondAttribute="bottom" id="AUI-34-A8q"/>
                             <constraint firstItem="mRv-xN-2YE" firstAttribute="top" secondItem="95U-3m-zpm" secondAttribute="bottom" constant="10" id="FtJ-cS-uLb"/>
+                            <constraint firstItem="GUX-tX-BgN" firstAttribute="bottom" secondItem="mRv-xN-2YE" secondAttribute="bottom" constant="-3" id="OuM-HF-hUL"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="nzP-Wy-2Cc" secondAttribute="trailing" constant="30" id="PPZ-N3-JLq"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="gpQ-xy-9dg" secondAttribute="trailing" id="Rrq-f8-qbx"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="gpQ-xy-9dg" secondAttribute="bottom" id="YMc-6A-uHS"/>
+                            <constraint firstItem="9Un-lM-k1k" firstAttribute="top" secondItem="95U-3m-zpm" secondAttribute="top" id="a6H-b7-MGk"/>
                             <constraint firstItem="tX0-lD-oD9" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="njU-sa-YsX"/>
                             <constraint firstItem="mRv-xN-2YE" firstAttribute="leading" secondItem="95U-3m-zpm" secondAttribute="leading" id="pwy-x2-V08"/>
                             <constraint firstItem="tX0-lD-oD9" firstAttribute="bottom" secondItem="gpQ-xy-9dg" secondAttribute="top" id="teA-uX-w16"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="nzP-Wy-2Cc" secondAttribute="bottom" constant="30" id="toy-ia-aog"/>
                             <constraint firstItem="gpQ-xy-9dg" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="xfz-X3-xjv"/>
+                            <constraint firstItem="9Un-lM-k1k" firstAttribute="trailing" secondItem="qdD-oX-Emq" secondAttribute="trailing" constant="80" id="yLF-fI-78Y"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="tX0-lD-oD9" secondAttribute="trailing" id="zwW-Ie-Azk"/>
                         </constraints>
                         <connections>
                             <outlet property="addTaskButton" destination="nzP-Wy-2Cc" id="jk8-KU-zYr"/>
+                            <outlet property="nextTabDayLabel" destination="9Un-lM-k1k" id="RqH-ri-kje"/>
                             <outlet property="remainingDayLabel" destination="95U-3m-zpm" id="MFE-Mf-Ec9"/>
                             <outlet property="remainingTotalExpectedHourLabel" destination="mRv-xN-2YE" id="tZj-Fn-Kmq"/>
                         </connections>
@@ -455,6 +472,9 @@
     </scenes>
     <resources>
         <image name="chevron.backward" catalog="system" width="96" height="128"/>
+        <systemColor name="placeholderTextColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -45,6 +45,15 @@
                                 <viewLayoutGuide key="contentLayoutGuide" id="v5d-0n-Gn0"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="v5f-K1-ftC"/>
                             </scrollView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nzP-Wy-2Cc">
+                                <rect key="frame" x="245" y="537" width="100" height="100"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="nzP-Wy-2Cc" secondAttribute="height" multiplier="1:1" id="eHK-Mg-F9g"/>
+                                    <constraint firstAttribute="width" constant="100" id="zpm-DI-1u2"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="qdD-oX-Emq"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -55,10 +64,13 @@
                             <constraint firstItem="fCi-yI-ELp" firstAttribute="top" secondItem="2p8-9T-bOw" secondAttribute="bottom" id="GFv-Vd-Kye"/>
                             <constraint firstItem="2p8-9T-bOw" firstAttribute="leading" secondItem="qdD-oX-Emq" secondAttribute="leading" id="Iht-6g-6gs"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="fCi-yI-ELp" secondAttribute="bottom" id="MzC-4b-7w5"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="nzP-Wy-2Cc" secondAttribute="trailing" constant="30" id="PPZ-N3-JLq"/>
                             <constraint firstItem="qdD-oX-Emq" firstAttribute="trailing" secondItem="2p8-9T-bOw" secondAttribute="trailing" id="bdD-xc-wxx"/>
+                            <constraint firstItem="qdD-oX-Emq" firstAttribute="bottom" secondItem="nzP-Wy-2Cc" secondAttribute="bottom" constant="30" id="toy-ia-aog"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="addTaskButton" destination="nzP-Wy-2Cc" id="mOr-QU-Dxv"/>
                         <outlet property="buttonBarView" destination="2p8-9T-bOw" id="Zuq-bS-Rss"/>
                         <outlet property="containerView" destination="fCi-yI-ELp" id="hpE-6M-raG"/>
                     </connections>
@@ -160,15 +172,6 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ejJ-c7-Zgb">
-                                <rect key="frame" x="245" y="537" width="100" height="100"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="ejJ-c7-Zgb" secondAttribute="height" multiplier="1:1" id="WOg-yZ-8E5"/>
-                                    <constraint firstAttribute="width" constant="100" id="pOx-7b-JkI"/>
-                                </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="button"/>
-                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -176,18 +179,15 @@
                             <constraint firstItem="RPT-NP-yvq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="6aU-jV-LZv"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="RPT-NP-yvq" secondAttribute="trailing" id="Kov-UT-3jp"/>
                             <constraint firstItem="lEE-MY-vKC" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="40" id="OQQ-Uk-nm9"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="ejJ-c7-Zgb" secondAttribute="bottom" constant="30" id="U2K-r9-QjV"/>
                             <constraint firstItem="lEE-MY-vKC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="bvD-zT-R9b"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="RPT-NP-yvq" secondAttribute="bottom" id="dGY-T5-XoN"/>
                             <constraint firstItem="aEW-xn-pU5" firstAttribute="leading" secondItem="lEE-MY-vKC" secondAttribute="leading" id="gQq-gV-8Cd"/>
                             <constraint firstItem="RPT-NP-yvq" firstAttribute="top" secondItem="aEW-xn-pU5" secondAttribute="bottom" constant="20" id="hlX-wK-Hmi"/>
                             <constraint firstItem="JmG-xk-gPy" firstAttribute="bottom" secondItem="aEW-xn-pU5" secondAttribute="bottom" id="lgJ-qV-1e6"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="ejJ-c7-Zgb" secondAttribute="trailing" constant="30" id="oYx-IU-36E"/>
                             <constraint firstItem="aEW-xn-pU5" firstAttribute="top" secondItem="lEE-MY-vKC" secondAttribute="bottom" constant="10" id="qP5-li-ouu"/>
                             <constraint firstItem="JmG-xk-gPy" firstAttribute="leading" secondItem="aEW-xn-pU5" secondAttribute="trailing" constant="20" id="yie-6b-rjU"/>
                         </constraints>
                         <connections>
-                            <outlet property="addTaskButton" destination="ejJ-c7-Zgb" id="a4V-4j-uTC"/>
                             <outlet property="remainingTextLabel" destination="JmG-xk-gPy" id="8gw-aZ-f8H"/>
                             <outlet property="remainingTimeLabel" destination="aEW-xn-pU5" id="PLj-DD-rjQ"/>
                             <outlet property="taskCollectionView" destination="RPT-NP-yvq" id="QeD-Ol-U9i"/>
@@ -370,7 +370,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jAF-6p-amF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1208.8" y="108.39580209895054"/>
+            <point key="canvasLocation" x="876" y="109"/>
         </scene>
     </scenes>
     <resources>

--- a/CapstoneProject/CapstoneProject/Views/HomeChildView.swift
+++ b/CapstoneProject/CapstoneProject/Views/HomeChildView.swift
@@ -11,6 +11,5 @@ public class HomeChildView: UIView {
     @IBOutlet public var tomorrowTextLabel: UILabel!
     @IBOutlet public var remainingTimeLabel: UILabel!
     @IBOutlet public var remainingTextLabel: UILabel!
-    @IBOutlet public var addTaskButton: UIButton!
     @IBOutlet public var taskCollectionView: UICollectionView!
 }

--- a/CapstoneProject/CapstoneProject/Views/HomeChildView.swift
+++ b/CapstoneProject/CapstoneProject/Views/HomeChildView.swift
@@ -8,8 +8,5 @@
 import UIKit
 
 public class HomeChildView: UIView {
-    @IBOutlet public var tomorrowTextLabel: UILabel!
-    @IBOutlet public var remainingTimeLabel: UILabel!
-    @IBOutlet public var remainingTextLabel: UILabel!
     @IBOutlet public var taskCollectionView: UICollectionView!
 }

--- a/CapstoneProject/CapstoneProject/Views/HomeChildView.swift
+++ b/CapstoneProject/CapstoneProject/Views/HomeChildView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public class HomeView: UIView {
+public class HomeChildView: UIView {
     @IBOutlet public var tomorrowTextLabel: UILabel!
     @IBOutlet public var remainingTimeLabel: UILabel!
     @IBOutlet public var remainingTextLabel: UILabel!

--- a/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
+++ b/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
@@ -1,0 +1,12 @@
+//
+//  HomeParentView.swift
+//  CapstoneProject
+//
+//  Created by 김승찬 on 2022/05/20.
+//
+
+import UIKit
+
+public class HomeParentView: UIView {
+    @IBOutlet var addTaskButton: UIButton!
+}

--- a/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
+++ b/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
@@ -11,4 +11,5 @@ public class HomeParentView: UIView {
     @IBOutlet var remainingDayLabel: UILabel!
     @IBOutlet var remainingTotalExpectedHourLabel: UILabel!
     @IBOutlet var addTaskButton: UIButton!
+    @IBOutlet var nextTabDayLabel: UILabel!
 }

--- a/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
+++ b/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
@@ -8,5 +8,6 @@
 import UIKit
 
 public class HomeParentView: UIView {
+    @IBOutlet var remainingDayLabel: UILabel!
     @IBOutlet var addTaskButton: UIButton!
 }

--- a/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
+++ b/CapstoneProject/CapstoneProject/Views/HomeParentView.swift
@@ -9,5 +9,6 @@ import UIKit
 
 public class HomeParentView: UIView {
     @IBOutlet var remainingDayLabel: UILabel!
+    @IBOutlet var remainingTotalExpectedHourLabel: UILabel!
     @IBOutlet var addTaskButton: UIButton!
 }

--- a/CapstoneProject/Podfile
+++ b/CapstoneProject/Podfile
@@ -1,0 +1,11 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'CapstoneProject' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for CapstoneProject
+  pod 'XLPagerTabStrip', '~> 9.0'
+
+end

--- a/CapstoneProject/Podfile.lock
+++ b/CapstoneProject/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - XLPagerTabStrip (9.0.0)
+
+DEPENDENCIES:
+  - XLPagerTabStrip (~> 9.0)
+
+SPEC REPOS:
+  trunk:
+    - XLPagerTabStrip
+
+SPEC CHECKSUMS:
+  XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
+
+PODFILE CHECKSUM: 3b776e19cd40583290fae6041b184f7919e48df1
+
+COCOAPODS: 1.11.2


### PR DESCRIPTION
# [feature/SwipeHomeVC] XLPagerTabStrip 적용  
## 개발 환경  
* Xcode 13.4  
* iOS 15.4.1  
* iPhone SE  

## 상세 설명  
<img width="500" alt="1" src="https://user-images.githubusercontent.com/63276842/169805629-83b976e3-c324-4a25-b0f5-2a8ae6e17069.png">  

* <Main> 화면에서, Task 그래프 영역을 Swipe하여 다음 탭으로 넘어갈 수 있도록 홈화면을 구현  
* [XLPagerTabStrip](https://github.com/xmartlabs/XLPagerTabStrip) 라이브러리에서 **Bar** 스타일 활용  
* 기존 HomeVC를 **HomeParentVC**와 **HomeChildVC**로 분리하여 구현  
  * HomeParentVC에는 컬렉션 뷰 상단 부분 (내일까지 ...)을 구현  
  * HomeChildVC에는 컬렉션 뷰(Task 그래프) 영역을 구현  