### PR TITLE
[feature/addTaskView] AddTaskVC에 StackView 적용

### DIFF
--- a/CapstoneProject/CapstoneProject/Controllers/AddTaskViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/AddTaskViewController.swift
@@ -15,17 +15,21 @@ public class AddTaskViewController: UIViewController {
         return (view as! AddTaskView)
     }
     
+    let datePicker: UIDatePicker = UIDatePicker()
+    let tapGesture: UITapGestureRecognizer = UITapGestureRecognizer()
     
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
         super.viewDidLoad()
+        self.addTaskView.taskNameTextField.delegate = self
+        self.addTaskView.dateTextField.delegate = self
+        self.tapGesture.delegate = self
+        
         setupBackButton()
         setupAddTaskButton()
-    }
-    
-    // TextField에서 다른 화면 터치 시, 키보드 dismiss.
-    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.addTaskView.endEditing(true)
+        setKeyboardActions()
+        setStackViewsCorners()
+        createDataPickerView()
     }
     
     private func setupBackButton() {
@@ -41,5 +45,85 @@ public class AddTaskViewController: UIViewController {
             self.presentingViewController?.dismiss(animated: true)
         }
         self.addTaskView.addTaskButton.addAction(action, for: .touchUpInside)
+    }
+    
+    // TextField에서 다른 화면 터치하거나 return키 입력 시, 키보드 dismiss.
+    // keyboard가 나타날 때 textField를 가리지 않도록, view의 높이 변화시킴.
+    private func setKeyboardActions() {
+        self.view.addGestureRecognizer(self.tapGesture)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    private func setStackViewsCorners() {
+        self.addTaskView.stackFirstView.layer.cornerRadius = 15
+        self.addTaskView.stackSecondView.layer.cornerRadius = 15
+    }
+}
+
+extension AddTaskViewController: UITextFieldDelegate, UIGestureRecognizerDelegate {
+    
+    // TextField에서 다른 화면 터치 시, 키보드 dismiss.
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        self.view.endEditing(true)
+        return true
+    }
+    
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+    @objc
+    func keyboardWillShow(_ sender: Notification) {
+        self.addTaskView.addTaskButton.isHidden = true
+        self.view.frame.origin.y = 0
+        if let keyboardFrame: NSValue = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            if keyboardHeight > 300 {
+                self.view.frame.origin.y = -200
+            } else {
+                self.view.frame.origin.y = -100
+            }
+        }
+    }
+    
+    @objc
+    func keyboardWillHide(_ sender: Notification) {
+        self.addTaskView.addTaskButton.isHidden = false
+        self.view.frame.origin.y = 0
+    }
+}
+
+extension AddTaskViewController {
+    
+    private func createDataPickerView() {
+        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: self.view.bounds.width, height: 45))
+        
+        let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: nil, action: #selector(donePressed))
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: nil, action: #selector(cancelPressed))
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        
+        toolbar.setItems([cancelButton, flexibleSpace, doneButton], animated: true)
+        self.addTaskView.dateTextField.inputAccessoryView = toolbar
+        self.addTaskView.dateTextField.inputView = datePicker
+        self.datePicker.datePickerMode = .date
+        self.datePicker.preferredDatePickerStyle = .inline
+    }
+    
+    @objc
+    func donePressed() {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        
+        self.addTaskView.dateTextField.text = formatter.string(from: datePicker.date)
+        self.view.endEditing(true)
+    }
+    
+    @objc
+    func cancelPressed() {
+        self.view.endEditing(true)
     }
 }

--- a/CapstoneProject/CapstoneProject/Controllers/AddTaskViewController.swift
+++ b/CapstoneProject/CapstoneProject/Controllers/AddTaskViewController.swift
@@ -15,7 +15,9 @@ public class AddTaskViewController: UIViewController {
         return (view as! AddTaskView)
     }
     
-    let datePicker: UIDatePicker = UIDatePicker()
+    let calendarDatePicker: UIDatePicker = UIDatePicker()
+    let timeDatePicker: UIDatePicker = UIDatePicker()
+    let expectedTimeDatePicker: UIDatePicker = UIDatePicker()
     let tapGesture: UITapGestureRecognizer = UITapGestureRecognizer()
     
     // MARK: - View Lifecycle
@@ -23,13 +25,14 @@ public class AddTaskViewController: UIViewController {
         super.viewDidLoad()
         self.addTaskView.taskNameTextField.delegate = self
         self.addTaskView.dateTextField.delegate = self
+        self.addTaskView.timeTextField.delegate = self
         self.tapGesture.delegate = self
         
         setupBackButton()
         setupAddTaskButton()
         setKeyboardActions()
         setStackViewsCorners()
-        createDataPickerView()
+        setDataPickerView()
     }
     
     private func setupBackButton() {
@@ -98,7 +101,7 @@ extension AddTaskViewController: UITextFieldDelegate, UIGestureRecognizerDelegat
 
 extension AddTaskViewController {
     
-    private func createDataPickerView() {
+    private func setDataPickerView() {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: self.view.bounds.width, height: 45))
         
         let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: nil, action: #selector(donePressed))
@@ -106,19 +109,61 @@ extension AddTaskViewController {
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
         
         toolbar.setItems([cancelButton, flexibleSpace, doneButton], animated: true)
+        
+        var components = DateComponents()
+        components.day = 0
+        let minDate = Calendar.autoupdatingCurrent.date(byAdding: components, to: Date())
+
         self.addTaskView.dateTextField.inputAccessoryView = toolbar
-        self.addTaskView.dateTextField.inputView = datePicker
-        self.datePicker.datePickerMode = .date
-        self.datePicker.preferredDatePickerStyle = .inline
+        self.addTaskView.dateTextField.inputView = calendarDatePicker
+        self.addTaskView.dateTextField.tintColor = .clear
+        
+        self.addTaskView.timeTextField.inputAccessoryView = toolbar
+        self.addTaskView.timeTextField.inputView = timeDatePicker
+        self.addTaskView.timeTextField.tintColor = .clear
+        
+        self.addTaskView.expectedTimeTextField.inputAccessoryView = toolbar
+        self.addTaskView.expectedTimeTextField.inputView = expectedTimeDatePicker
+        self.addTaskView.expectedTimeTextField.tintColor = .clear
+        
+        self.calendarDatePicker.locale = Locale(identifier: "ko-KR")
+        self.calendarDatePicker.datePickerMode = .date
+        self.calendarDatePicker.preferredDatePickerStyle = .inline
+        self.calendarDatePicker.minimumDate = minDate
+        
+        self.timeDatePicker.locale = Locale(identifier: "ko-KR")
+        self.timeDatePicker.datePickerMode = .time
+        self.timeDatePicker.preferredDatePickerStyle = .wheels
+        
+        self.expectedTimeDatePicker.locale = Locale(identifier: "ko-KR")
+        self.expectedTimeDatePicker.datePickerMode = .countDownTimer
+        self.expectedTimeDatePicker.preferredDatePickerStyle = .automatic
+        self.expectedTimeDatePicker.minuteInterval = 15
     }
     
     @objc
     func donePressed() {
         let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
+        formatter.locale = Locale(identifier: "ko-KR")
         
-        self.addTaskView.dateTextField.text = formatter.string(from: datePicker.date)
+        if self.addTaskView.dateTextField.isEditing {
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            self.addTaskView.dateTextField.text = formatter.string(from: calendarDatePicker.date)
+        }
+        
+        if self.addTaskView.timeTextField.isEditing {
+            formatter.dateStyle = .none
+            formatter.timeStyle = .short
+            self.addTaskView.timeTextField.text = formatter.string(from: timeDatePicker.date)
+        }
+        
+        if self.addTaskView.expectedTimeTextField.isEditing {
+            formatter.dateStyle = .none
+            formatter.timeStyle = .short
+            self.addTaskView.expectedTimeTextField.text = "\(expectedTimeDatePicker.countDownDuration / 60) 분"
+        }
+        
         self.view.endEditing(true)
     }
     

--- a/CapstoneProject/CapstoneProject/Resources/Info.plist
+++ b/CapstoneProject/CapstoneProject/Resources/Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
+</dict>
 </plist>

--- a/CapstoneProject/CapstoneProject/Views/AddTaskView.swift
+++ b/CapstoneProject/CapstoneProject/Views/AddTaskView.swift
@@ -15,4 +15,5 @@ public class AddTaskView: UIView {
     @IBOutlet public var stackSecondView: UIView!
     @IBOutlet public var dateTextField: UITextField!
     @IBOutlet public var timeTextField: UITextField!
+    @IBOutlet public var expectedTimeTextField: UITextField!
 }

--- a/CapstoneProject/CapstoneProject/Views/AddTaskView.swift
+++ b/CapstoneProject/CapstoneProject/Views/AddTaskView.swift
@@ -11,4 +11,8 @@ public class AddTaskView: UIView {
     @IBOutlet public var backButton: UIButton!
     @IBOutlet public var taskNameTextField: UITextField!
     @IBOutlet public var addTaskButton: UIButton!
+    @IBOutlet public var stackFirstView: UIView!
+    @IBOutlet public var stackSecondView: UIView!
+    @IBOutlet public var dateTextField: UITextField!
+    @IBOutlet public var timeTextField: UITextField!
 }

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -137,139 +137,175 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XJM-jO-aJv">
-                                <rect key="frame" x="0.0" y="125" width="375" height="542"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t7l-s1-qZN">
+                                <rect key="frame" x="0.0" y="125" width="375" height="472"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KBu-NN-IBT" userLabel="firstView">
-                                        <rect key="frame" x="25" y="0.0" width="325" height="370"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XJM-jO-aJv">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="530"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zkp-tY-L3b">
-                                                <rect key="frame" x="30" y="30" width="31.5" height="21.5"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="여기에 이름을 적어주세요." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="YTZ-Cj-OlK">
-                                                <rect key="frame" x="30" y="61.5" width="185.5" height="40"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KBu-NN-IBT" userLabel="firstView">
+                                                <rect key="frame" x="25" y="0.0" width="325" height="370"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zkp-tY-L3b">
+                                                        <rect key="frame" x="30" y="30" width="31.5" height="21.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="여기에 이름을 적어주세요." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="YTZ-Cj-OlK">
+                                                        <rect key="frame" x="30" y="61.5" width="185.5" height="35"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="35" id="4IP-I2-TnE"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bqn-VN-Tor" userLabel="divider">
+                                                        <rect key="frame" x="30" y="111.5" width="265" height="0.5"/>
+                                                        <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="0.5" id="pmi-D0-m4I"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="카테고리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LYX-7s-QZm">
+                                                        <rect key="frame" x="30" y="142" width="62.5" height="21.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OGH-La-UYF" userLabel="과제">
+                                                        <rect key="frame" x="30" y="183.5" width="48.5" height="25"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="25" id="kmx-Xt-IAU"/>
+                                                        </constraints>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="filled" title="과제">
+                                                            <color key="baseBackgroundColor" red="0.29720994830000003" green="0.36420702929999998" blue="0.82357066869999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                        </buttonConfiguration>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="36S-A7-2p0">
+                                                        <rect key="frame" x="98.5" y="183.5" width="72.5" height="25"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="filled" title="프로젝트">
+                                                            <color key="baseBackgroundColor" red="0.96627050640000001" green="0.78904312850000002" blue="0.270414561" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                        </buttonConfiguration>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zor-P6-dOg">
+                                                        <rect key="frame" x="191" y="183.5" width="72.5" height="25"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="filled" title="시험준비">
+                                                            <color key="baseBackgroundColor" red="0.1620797813" green="0.083154596390000002" blue="0.525521338" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                        </buttonConfiguration>
+                                                    </button>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vWc-Dp-Ld6" userLabel="divider">
+                                                        <rect key="frame" x="30" y="233.5" width="265" height="0.5"/>
+                                                        <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="0.5" id="tNP-P6-2FI"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기한" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fep-fT-o8f">
+                                                        <rect key="frame" x="30" y="264" width="31.5" height="21.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="날짜 선택하기" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FAp-vT-8Dg">
+                                                        <rect key="frame" x="30" y="300.5" width="98" height="35"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="35" id="b7s-fE-BM6"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="시간 선택하기" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Rvs-IB-hfe">
+                                                        <rect key="frame" x="197" y="300.5" width="98" height="35"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="35" id="Z53-oy-Z0X"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="4IP-I2-TnE"/>
+                                                    <constraint firstItem="Zkp-tY-L3b" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="0Sx-JW-U29"/>
+                                                    <constraint firstItem="bqn-VN-Tor" firstAttribute="top" secondItem="YTZ-Cj-OlK" secondAttribute="bottom" constant="15" id="1Rt-ym-mlV"/>
+                                                    <constraint firstItem="LYX-7s-QZm" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="3NG-1t-WMU"/>
+                                                    <constraint firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" constant="30" id="3Vd-F0-B5q"/>
+                                                    <constraint firstItem="Zor-P6-dOg" firstAttribute="height" secondItem="OGH-La-UYF" secondAttribute="height" id="4Qa-O7-OHr"/>
+                                                    <constraint firstItem="OGH-La-UYF" firstAttribute="leading" secondItem="LYX-7s-QZm" secondAttribute="leading" id="6HL-y7-iga"/>
+                                                    <constraint firstItem="YTZ-Cj-OlK" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="6Qb-fN-XFC"/>
+                                                    <constraint firstItem="YTZ-Cj-OlK" firstAttribute="top" secondItem="Zkp-tY-L3b" secondAttribute="bottom" constant="10" id="7tH-aE-9Wb"/>
+                                                    <constraint firstAttribute="height" constant="370" id="COL-N7-1eY"/>
+                                                    <constraint firstItem="bqn-VN-Tor" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="Fzb-B4-8Gt"/>
+                                                    <constraint firstItem="Zkp-tY-L3b" firstAttribute="top" secondItem="KBu-NN-IBT" secondAttribute="top" constant="30" id="Lbd-N8-lUz"/>
+                                                    <constraint firstItem="FAp-vT-8Dg" firstAttribute="leading" secondItem="fep-fT-o8f" secondAttribute="leading" id="PGA-fu-XnY"/>
+                                                    <constraint firstItem="fep-fT-o8f" firstAttribute="top" secondItem="vWc-Dp-Ld6" secondAttribute="bottom" constant="30" id="SAN-8J-twf"/>
+                                                    <constraint firstItem="Zor-P6-dOg" firstAttribute="leading" secondItem="36S-A7-2p0" secondAttribute="trailing" constant="20" id="XuV-kO-d1G"/>
+                                                    <constraint firstItem="36S-A7-2p0" firstAttribute="height" secondItem="OGH-La-UYF" secondAttribute="height" id="Zqa-EL-Y2d"/>
+                                                    <constraint firstItem="Rvs-IB-hfe" firstAttribute="centerY" secondItem="FAp-vT-8Dg" secondAttribute="centerY" id="b1a-8P-Zqh"/>
+                                                    <constraint firstItem="OGH-La-UYF" firstAttribute="top" secondItem="LYX-7s-QZm" secondAttribute="bottom" constant="20" id="e1P-wd-o5s"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Rvs-IB-hfe" secondAttribute="trailing" constant="30" id="ea9-c3-pbP"/>
+                                                    <constraint firstItem="FAp-vT-8Dg" firstAttribute="top" secondItem="fep-fT-o8f" secondAttribute="bottom" constant="15" id="hTr-e0-DbH"/>
+                                                    <constraint firstItem="fep-fT-o8f" firstAttribute="leading" secondItem="LYX-7s-QZm" secondAttribute="leading" id="k7R-x7-LW8"/>
+                                                    <constraint firstItem="vWc-Dp-Ld6" firstAttribute="top" secondItem="OGH-La-UYF" secondAttribute="bottom" constant="25" id="lV1-oB-BdY"/>
+                                                    <constraint firstItem="vWc-Dp-Ld6" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="oZX-Jn-reb"/>
+                                                    <constraint firstItem="Zor-P6-dOg" firstAttribute="centerY" secondItem="36S-A7-2p0" secondAttribute="centerY" id="ujs-tC-aNZ"/>
+                                                    <constraint firstAttribute="trailing" secondItem="vWc-Dp-Ld6" secondAttribute="trailing" constant="30" id="uo1-7v-sJn"/>
+                                                    <constraint firstItem="36S-A7-2p0" firstAttribute="centerY" secondItem="OGH-La-UYF" secondAttribute="centerY" id="y8k-Hp-X4G"/>
+                                                    <constraint firstItem="36S-A7-2p0" firstAttribute="leading" secondItem="OGH-La-UYF" secondAttribute="trailing" constant="20" id="ypd-8k-b02"/>
+                                                    <constraint firstItem="LYX-7s-QZm" firstAttribute="top" secondItem="bqn-VN-Tor" secondAttribute="bottom" constant="30" id="zIR-Ro-Lmp"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bqn-VN-Tor" userLabel="divider">
-                                                <rect key="frame" x="30" y="116.5" width="265" height="0.5"/>
-                                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x0u-Zu-Z2T" userLabel="secondView">
+                                                <rect key="frame" x="25" y="390" width="325" height="140"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="예상 필요시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e5y-Tq-emJ">
+                                                        <rect key="frame" x="30" y="30" width="98" height="21.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="몇 시간이 필요한가요?" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0iz-JT-aXL">
+                                                        <rect key="frame" x="30" y="66.5" width="158.5" height="35"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="35" id="If8-yQ-9Dr"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="0.5" id="pmi-D0-m4I"/>
+                                                    <constraint firstItem="e5y-Tq-emJ" firstAttribute="top" secondItem="x0u-Zu-Z2T" secondAttribute="top" constant="30" id="4hM-Ub-r1o"/>
+                                                    <constraint firstItem="e5y-Tq-emJ" firstAttribute="leading" secondItem="x0u-Zu-Z2T" secondAttribute="leading" constant="30" id="8mt-t3-lp0"/>
+                                                    <constraint firstItem="0iz-JT-aXL" firstAttribute="top" secondItem="e5y-Tq-emJ" secondAttribute="bottom" constant="15" id="EsG-Y4-mYB"/>
+                                                    <constraint firstItem="0iz-JT-aXL" firstAttribute="leading" secondItem="e5y-Tq-emJ" secondAttribute="leading" id="Tin-ZS-cn2"/>
+                                                    <constraint firstAttribute="height" constant="140" id="uvg-AG-Z1e"/>
                                                 </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="카테고리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LYX-7s-QZm">
-                                                <rect key="frame" x="30" y="147" width="62.5" height="21.5"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OGH-La-UYF" userLabel="과제">
-                                                <rect key="frame" x="30" y="188.5" width="48.5" height="25"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="25" id="kmx-Xt-IAU"/>
-                                                </constraints>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="filled" title="과제">
-                                                    <color key="baseBackgroundColor" red="0.29720994830000003" green="0.36420702929999998" blue="0.82357066869999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                </buttonConfiguration>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="36S-A7-2p0">
-                                                <rect key="frame" x="98.5" y="188.5" width="72.5" height="25"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="filled" title="프로젝트">
-                                                    <color key="baseBackgroundColor" red="0.96627050640000001" green="0.78904312850000002" blue="0.270414561" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                </buttonConfiguration>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zor-P6-dOg">
-                                                <rect key="frame" x="191" y="188.5" width="72.5" height="25"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="filled" title="시험준비">
-                                                    <color key="baseBackgroundColor" red="0.1620797813" green="0.083154596390000002" blue="0.525521338" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                </buttonConfiguration>
-                                            </button>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vWc-Dp-Ld6" userLabel="divider">
-                                                <rect key="frame" x="30" y="238.5" width="265" height="0.5"/>
-                                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="0.5" id="tNP-P6-2FI"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기한" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fep-fT-o8f">
-                                                <rect key="frame" x="30" y="269" width="31.5" height="21.5"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="날짜 선택하기" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FAp-vT-8Dg">
-                                                <rect key="frame" x="30" y="305.5" width="98" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="b7s-fE-BM6"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="시간 선택하기" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Rvs-IB-hfe">
-                                                <rect key="frame" x="197" y="305.5" width="98" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="Z53-oy-Z0X"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" red="0.97647064920000004" green="0.97647064920000004" blue="0.97647064920000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
-                                            <constraint firstItem="Zkp-tY-L3b" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="0Sx-JW-U29"/>
-                                            <constraint firstItem="bqn-VN-Tor" firstAttribute="top" secondItem="YTZ-Cj-OlK" secondAttribute="bottom" constant="15" id="1Rt-ym-mlV"/>
-                                            <constraint firstItem="LYX-7s-QZm" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="3NG-1t-WMU"/>
-                                            <constraint firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" constant="30" id="3Vd-F0-B5q"/>
-                                            <constraint firstItem="Zor-P6-dOg" firstAttribute="height" secondItem="OGH-La-UYF" secondAttribute="height" id="4Qa-O7-OHr"/>
-                                            <constraint firstItem="OGH-La-UYF" firstAttribute="leading" secondItem="LYX-7s-QZm" secondAttribute="leading" id="6HL-y7-iga"/>
-                                            <constraint firstItem="YTZ-Cj-OlK" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="6Qb-fN-XFC"/>
-                                            <constraint firstItem="YTZ-Cj-OlK" firstAttribute="top" secondItem="Zkp-tY-L3b" secondAttribute="bottom" constant="10" id="7tH-aE-9Wb"/>
-                                            <constraint firstAttribute="height" constant="370" id="COL-N7-1eY"/>
-                                            <constraint firstItem="bqn-VN-Tor" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="Fzb-B4-8Gt"/>
-                                            <constraint firstItem="Zkp-tY-L3b" firstAttribute="top" secondItem="KBu-NN-IBT" secondAttribute="top" constant="30" id="Lbd-N8-lUz"/>
-                                            <constraint firstItem="FAp-vT-8Dg" firstAttribute="leading" secondItem="fep-fT-o8f" secondAttribute="leading" id="PGA-fu-XnY"/>
-                                            <constraint firstItem="fep-fT-o8f" firstAttribute="top" secondItem="vWc-Dp-Ld6" secondAttribute="bottom" constant="30" id="SAN-8J-twf"/>
-                                            <constraint firstItem="Zor-P6-dOg" firstAttribute="leading" secondItem="36S-A7-2p0" secondAttribute="trailing" constant="20" id="XuV-kO-d1G"/>
-                                            <constraint firstItem="36S-A7-2p0" firstAttribute="height" secondItem="OGH-La-UYF" secondAttribute="height" id="Zqa-EL-Y2d"/>
-                                            <constraint firstItem="Rvs-IB-hfe" firstAttribute="centerY" secondItem="FAp-vT-8Dg" secondAttribute="centerY" id="b1a-8P-Zqh"/>
-                                            <constraint firstItem="OGH-La-UYF" firstAttribute="top" secondItem="LYX-7s-QZm" secondAttribute="bottom" constant="20" id="e1P-wd-o5s"/>
-                                            <constraint firstItem="FAp-vT-8Dg" firstAttribute="top" secondItem="fep-fT-o8f" secondAttribute="bottom" constant="15" id="hTr-e0-DbH"/>
-                                            <constraint firstItem="fep-fT-o8f" firstAttribute="leading" secondItem="LYX-7s-QZm" secondAttribute="leading" id="k7R-x7-LW8"/>
-                                            <constraint firstItem="vWc-Dp-Ld6" firstAttribute="top" secondItem="OGH-La-UYF" secondAttribute="bottom" constant="25" id="lV1-oB-BdY"/>
-                                            <constraint firstItem="vWc-Dp-Ld6" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="oZX-Jn-reb"/>
-                                            <constraint firstItem="Zor-P6-dOg" firstAttribute="centerY" secondItem="36S-A7-2p0" secondAttribute="centerY" id="ujs-tC-aNZ"/>
-                                            <constraint firstAttribute="trailing" secondItem="vWc-Dp-Ld6" secondAttribute="trailing" constant="30" id="uo1-7v-sJn"/>
-                                            <constraint firstItem="36S-A7-2p0" firstAttribute="centerY" secondItem="OGH-La-UYF" secondAttribute="centerY" id="y8k-Hp-X4G"/>
-                                            <constraint firstItem="36S-A7-2p0" firstAttribute="leading" secondItem="OGH-La-UYF" secondAttribute="trailing" constant="20" id="ypd-8k-b02"/>
-                                            <constraint firstItem="LYX-7s-QZm" firstAttribute="top" secondItem="bqn-VN-Tor" secondAttribute="bottom" constant="30" id="zIR-Ro-Lmp"/>
+                                            <constraint firstItem="x0u-Zu-Z2T" firstAttribute="trailing" secondItem="KBu-NN-IBT" secondAttribute="trailing" id="HCI-kK-5Zw"/>
+                                            <constraint firstItem="x0u-Zu-Z2T" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" id="O7q-yk-DNh"/>
+                                            <constraint firstItem="KBu-NN-IBT" firstAttribute="leading" secondItem="XJM-jO-aJv" secondAttribute="leading" constant="25" id="Tdf-Yd-wUF"/>
+                                            <constraint firstAttribute="bottom" secondItem="x0u-Zu-Z2T" secondAttribute="bottom" id="ZKk-G9-qSE"/>
+                                            <constraint firstAttribute="trailing" secondItem="KBu-NN-IBT" secondAttribute="trailing" constant="25" id="ZqM-OC-l9F"/>
+                                            <constraint firstItem="x0u-Zu-Z2T" firstAttribute="top" secondItem="KBu-NN-IBT" secondAttribute="bottom" constant="20" id="icd-Ye-GpT"/>
+                                            <constraint firstItem="KBu-NN-IBT" firstAttribute="top" secondItem="XJM-jO-aJv" secondAttribute="top" id="ndY-nS-OIH"/>
                                         </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x0u-Zu-Z2T" userLabel="secondView">
-                                        <rect key="frame" x="25" y="390" width="325" height="152"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    </view>
+                                    </stackView>
                                 </subviews>
-                                <color key="backgroundColor" red="0.97647064920000004" green="0.97647064920000004" blue="0.97647064920000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
-                                    <constraint firstItem="x0u-Zu-Z2T" firstAttribute="trailing" secondItem="KBu-NN-IBT" secondAttribute="trailing" id="HCI-kK-5Zw"/>
-                                    <constraint firstItem="x0u-Zu-Z2T" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" id="O7q-yk-DNh"/>
-                                    <constraint firstItem="KBu-NN-IBT" firstAttribute="leading" secondItem="XJM-jO-aJv" secondAttribute="leading" constant="25" id="Tdf-Yd-wUF"/>
-                                    <constraint firstAttribute="bottom" secondItem="x0u-Zu-Z2T" secondAttribute="bottom" id="ZKk-G9-qSE"/>
-                                    <constraint firstAttribute="trailing" secondItem="KBu-NN-IBT" secondAttribute="trailing" constant="25" id="ZqM-OC-l9F"/>
-                                    <constraint firstItem="x0u-Zu-Z2T" firstAttribute="top" secondItem="KBu-NN-IBT" secondAttribute="bottom" constant="20" id="icd-Ye-GpT"/>
-                                    <constraint firstItem="KBu-NN-IBT" firstAttribute="top" secondItem="XJM-jO-aJv" secondAttribute="top" id="ndY-nS-OIH"/>
+                                    <constraint firstItem="XJM-jO-aJv" firstAttribute="bottom" secondItem="t7l-s1-qZN" secondAttribute="bottom" id="As7-WR-lIJ"/>
+                                    <constraint firstItem="XJM-jO-aJv" firstAttribute="top" secondItem="t7l-s1-qZN" secondAttribute="top" id="GLi-Vq-nDT"/>
+                                    <constraint firstItem="XJM-jO-aJv" firstAttribute="trailing" secondItem="t7l-s1-qZN" secondAttribute="trailing" id="IqB-VM-RnR"/>
+                                    <constraint firstItem="XJM-jO-aJv" firstAttribute="width" secondItem="t7l-s1-qZN" secondAttribute="width" id="yK2-3y-0wM"/>
+                                    <constraint firstItem="XJM-jO-aJv" firstAttribute="leading" secondItem="t7l-s1-qZN" secondAttribute="leading" id="zcW-Y6-Cx9"/>
                                 </constraints>
-                            </stackView>
+                            </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dae-6q-WZV">
                                 <rect key="frame" x="30" y="592" width="315" height="45"/>
                                 <constraints>
@@ -284,30 +320,36 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="KYH-Jd-olP"/>
                         <color key="backgroundColor" red="0.97647064920000004" green="0.97647064920000004" blue="0.97647064920000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <gestureRecognizers/>
                         <constraints>
+                            <constraint firstItem="t7l-s1-qZN" firstAttribute="top" secondItem="yH0-gl-Km4" secondAttribute="bottom" constant="15" id="1PL-EX-n7K"/>
                             <constraint firstItem="dg3-sz-GwB" firstAttribute="top" secondItem="KYH-Jd-olP" secondAttribute="top" constant="20" id="2cZ-Km-ipm"/>
-                            <constraint firstItem="KYH-Jd-olP" firstAttribute="trailing" secondItem="XJM-jO-aJv" secondAttribute="trailing" id="4j8-9A-cXy"/>
                             <constraint firstItem="yH0-gl-Km4" firstAttribute="top" secondItem="dg3-sz-GwB" secondAttribute="bottom" constant="10" id="6DN-D6-faj"/>
                             <constraint firstItem="dg3-sz-GwB" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" constant="5" id="8a6-wn-VL6"/>
-                            <constraint firstItem="KBu-NN-IBT" firstAttribute="trailing" secondItem="Rvs-IB-hfe" secondAttribute="trailing" constant="30" id="FaO-Yy-5Jy"/>
+                            <constraint firstItem="t7l-s1-qZN" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" id="Vp9-UF-Um7"/>
+                            <constraint firstItem="Dae-6q-WZV" firstAttribute="top" secondItem="t7l-s1-qZN" secondAttribute="bottom" constant="-5" id="fW1-S9-j70"/>
                             <constraint firstItem="KYH-Jd-olP" firstAttribute="bottom" secondItem="Dae-6q-WZV" secondAttribute="bottom" constant="30" id="fnp-Xr-IKx"/>
                             <constraint firstItem="Dae-6q-WZV" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" constant="30" id="n8J-1z-5tm"/>
-                            <constraint firstItem="XJM-jO-aJv" firstAttribute="top" secondItem="yH0-gl-Km4" secondAttribute="bottom" constant="15" id="rJh-or-dtg"/>
+                            <constraint firstItem="KYH-Jd-olP" firstAttribute="trailing" secondItem="t7l-s1-qZN" secondAttribute="trailing" id="qIf-2U-61Z"/>
                             <constraint firstItem="yH0-gl-Km4" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" constant="30" id="sop-SS-ncC"/>
-                            <constraint firstItem="XJM-jO-aJv" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" id="ujx-J9-q8A"/>
-                            <constraint firstItem="KYH-Jd-olP" firstAttribute="bottom" secondItem="XJM-jO-aJv" secondAttribute="bottom" id="vAR-4X-02g"/>
                             <constraint firstItem="KYH-Jd-olP" firstAttribute="trailing" secondItem="Dae-6q-WZV" secondAttribute="trailing" constant="30" id="wAz-46-Pct"/>
                         </constraints>
                         <connections>
                             <outlet property="addTaskButton" destination="Dae-6q-WZV" id="7hP-dX-OID"/>
                             <outlet property="backButton" destination="dg3-sz-GwB" id="7d8-gt-sPq"/>
+                            <outlet property="dateTextField" destination="FAp-vT-8Dg" id="0pa-nJ-bBF"/>
+                            <outlet property="stackFirstView" destination="KBu-NN-IBT" id="qZS-cL-zPu"/>
+                            <outlet property="stackSecondView" destination="x0u-Zu-Z2T" id="DKv-8Q-THV"/>
                             <outlet property="taskNameTextField" destination="YTZ-Cj-OlK" id="5Tw-W2-1hz"/>
+                            <outlet property="timeTextField" destination="Rvs-IB-hfe" id="aHr-f6-xe9"/>
+                            <outletCollection property="gestureRecognizers" destination="DqS-z8-8Oa" appends="YES" id="Lmf-xm-9by"/>
                         </connections>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jAF-6p-amF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="DqS-z8-8Oa"/>
             </objects>
-            <point key="canvasLocation" x="876" y="108.39580209895054"/>
+            <point key="canvasLocation" x="480.80000000000001" y="106.59670164917542"/>
         </scene>
         <!--Tomorrow Child View Controller-->
         <scene sceneID="tne-QT-ifu">

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -153,7 +153,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="여기에 이름을 적어주세요." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="YTZ-Cj-OlK">
-                                                        <rect key="frame" x="30" y="61.5" width="185.5" height="35"/>
+                                                        <rect key="frame" x="30" y="61.5" width="265" height="35"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="35" id="4IP-I2-TnE"/>
                                                         </constraints>
@@ -247,6 +247,7 @@
                                                     <constraint firstItem="Rvs-IB-hfe" firstAttribute="centerY" secondItem="FAp-vT-8Dg" secondAttribute="centerY" id="b1a-8P-Zqh"/>
                                                     <constraint firstItem="OGH-La-UYF" firstAttribute="top" secondItem="LYX-7s-QZm" secondAttribute="bottom" constant="20" id="e1P-wd-o5s"/>
                                                     <constraint firstAttribute="trailing" secondItem="Rvs-IB-hfe" secondAttribute="trailing" constant="30" id="ea9-c3-pbP"/>
+                                                    <constraint firstAttribute="trailing" secondItem="YTZ-Cj-OlK" secondAttribute="trailing" constant="30" id="f3S-iM-2FO"/>
                                                     <constraint firstItem="FAp-vT-8Dg" firstAttribute="top" secondItem="fep-fT-o8f" secondAttribute="bottom" constant="15" id="hTr-e0-DbH"/>
                                                     <constraint firstItem="fep-fT-o8f" firstAttribute="leading" secondItem="LYX-7s-QZm" secondAttribute="leading" id="k7R-x7-LW8"/>
                                                     <constraint firstItem="vWc-Dp-Ld6" firstAttribute="top" secondItem="OGH-La-UYF" secondAttribute="bottom" constant="25" id="lV1-oB-BdY"/>
@@ -268,7 +269,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="몇 시간이 필요한가요?" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0iz-JT-aXL">
-                                                        <rect key="frame" x="30" y="66.5" width="158.5" height="35"/>
+                                                        <rect key="frame" x="30" y="66.5" width="265" height="35"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="35" id="If8-yQ-9Dr"/>
                                                         </constraints>
@@ -282,6 +283,7 @@
                                                     <constraint firstItem="e5y-Tq-emJ" firstAttribute="leading" secondItem="x0u-Zu-Z2T" secondAttribute="leading" constant="30" id="8mt-t3-lp0"/>
                                                     <constraint firstItem="0iz-JT-aXL" firstAttribute="top" secondItem="e5y-Tq-emJ" secondAttribute="bottom" constant="15" id="EsG-Y4-mYB"/>
                                                     <constraint firstItem="0iz-JT-aXL" firstAttribute="leading" secondItem="e5y-Tq-emJ" secondAttribute="leading" id="Tin-ZS-cn2"/>
+                                                    <constraint firstAttribute="trailing" secondItem="0iz-JT-aXL" secondAttribute="trailing" constant="30" id="pYq-mf-AOZ"/>
                                                     <constraint firstAttribute="height" constant="140" id="uvg-AG-Z1e"/>
                                                 </constraints>
                                             </view>
@@ -338,6 +340,7 @@
                             <outlet property="addTaskButton" destination="Dae-6q-WZV" id="7hP-dX-OID"/>
                             <outlet property="backButton" destination="dg3-sz-GwB" id="7d8-gt-sPq"/>
                             <outlet property="dateTextField" destination="FAp-vT-8Dg" id="0pa-nJ-bBF"/>
+                            <outlet property="expectedTimeTextField" destination="0iz-JT-aXL" id="npP-q7-DPg"/>
                             <outlet property="stackFirstView" destination="KBu-NN-IBT" id="qZS-cL-zPu"/>
                             <outlet property="stackSecondView" destination="x0u-Zu-Z2T" id="DKv-8Q-THV"/>
                             <outlet property="taskNameTextField" destination="YTZ-Cj-OlK" id="5Tw-W2-1hz"/>
@@ -384,8 +387,11 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="캡스톤 앱 구현" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FWD-xs-3LE">
-                                                    <rect key="frame" x="45" y="8" width="97" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <rect key="frame" x="45" y="8" width="91.5" height="18"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="18" id="gIR-el-Guv"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -398,7 +404,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kmT-xh-0dX">
-                                                    <rect key="frame" x="45" y="38.5" width="40.5" height="20.5"/>
+                                                    <rect key="frame" x="45" y="33" width="40.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -412,7 +418,7 @@
                                                 <constraint firstItem="KmM-oM-cLL" firstAttribute="top" secondItem="ZpF-NW-dp3" secondAttribute="top" constant="5" id="KL9-Aa-y65"/>
                                                 <constraint firstItem="X9C-gP-HNA" firstAttribute="bottom" secondItem="KmM-oM-cLL" secondAttribute="bottom" constant="-3" id="MaP-oD-KdL"/>
                                                 <constraint firstItem="kmT-xh-0dX" firstAttribute="leading" secondItem="FWD-xs-3LE" secondAttribute="leading" id="SJ4-qp-LrI"/>
-                                                <constraint firstItem="kmT-xh-0dX" firstAttribute="top" secondItem="FWD-xs-3LE" secondAttribute="bottom" constant="10" id="rQU-SB-nRw"/>
+                                                <constraint firstItem="kmT-xh-0dX" firstAttribute="top" secondItem="FWD-xs-3LE" secondAttribute="bottom" constant="7" id="rQU-SB-nRw"/>
                                                 <constraint firstItem="KmM-oM-cLL" firstAttribute="leading" secondItem="ZpF-NW-dp3" secondAttribute="leading" constant="15" id="vCm-cp-Y5a"/>
                                             </constraints>
                                         </collectionViewCellContentView>

--- a/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
+++ b/CapstoneProject/CapstoneProject/Views/Base.lproj/Main.storyboard
@@ -119,7 +119,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dg3-sz-GwB">
-                                <rect key="frame" x="5" y="15" width="40" height="40"/>
+                                <rect key="frame" x="5" y="20" width="40" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="dg3-sz-GwB" secondAttribute="height" multiplier="1:1" id="Hfb-53-mcC"/>
                                     <constraint firstAttribute="width" constant="40" id="SYj-T9-f5W"/>
@@ -129,97 +129,149 @@
                                 <buttonConfiguration key="configuration" style="plain" image="chevron.backward" catalog="system"/>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="할일 추가하기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yH0-gl-Km4">
-                                <rect key="frame" x="30" y="75" width="136" height="30"/>
+                                <rect key="frame" x="30" y="70" width="135.5" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="92u-th-rgE"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zkp-tY-L3b">
-                                <rect key="frame" x="30" y="145" width="31.5" height="21.5"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="여기에 이름을 적어주세요." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="YTZ-Cj-OlK">
-                                <rect key="frame" x="101.5" y="136" width="233.5" height="40"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XJM-jO-aJv">
+                                <rect key="frame" x="0.0" y="125" width="375" height="542"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KBu-NN-IBT" userLabel="firstView">
+                                        <rect key="frame" x="25" y="0.0" width="325" height="370"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zkp-tY-L3b">
+                                                <rect key="frame" x="30" y="30" width="31.5" height="21.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="여기에 이름을 적어주세요." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="YTZ-Cj-OlK">
+                                                <rect key="frame" x="30" y="61.5" width="185.5" height="40"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="40" id="4IP-I2-TnE"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bqn-VN-Tor" userLabel="divider">
+                                                <rect key="frame" x="30" y="116.5" width="265" height="0.5"/>
+                                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="0.5" id="pmi-D0-m4I"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="카테고리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LYX-7s-QZm">
+                                                <rect key="frame" x="30" y="147" width="62.5" height="21.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OGH-La-UYF" userLabel="과제">
+                                                <rect key="frame" x="30" y="188.5" width="48.5" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="kmx-Xt-IAU"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="filled" title="과제">
+                                                    <color key="baseBackgroundColor" red="0.29720994830000003" green="0.36420702929999998" blue="0.82357066869999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                </buttonConfiguration>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="36S-A7-2p0">
+                                                <rect key="frame" x="98.5" y="188.5" width="72.5" height="25"/>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="filled" title="프로젝트">
+                                                    <color key="baseBackgroundColor" red="0.96627050640000001" green="0.78904312850000002" blue="0.270414561" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                </buttonConfiguration>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zor-P6-dOg">
+                                                <rect key="frame" x="191" y="188.5" width="72.5" height="25"/>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="filled" title="시험준비">
+                                                    <color key="baseBackgroundColor" red="0.1620797813" green="0.083154596390000002" blue="0.525521338" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                </buttonConfiguration>
+                                            </button>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vWc-Dp-Ld6" userLabel="divider">
+                                                <rect key="frame" x="30" y="238.5" width="265" height="0.5"/>
+                                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="0.5" id="tNP-P6-2FI"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기한" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fep-fT-o8f">
+                                                <rect key="frame" x="30" y="269" width="31.5" height="21.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="날짜 선택하기" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FAp-vT-8Dg">
+                                                <rect key="frame" x="30" y="305.5" width="98" height="40"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="40" id="b7s-fE-BM6"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="시간 선택하기" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Rvs-IB-hfe">
+                                                <rect key="frame" x="197" y="305.5" width="98" height="40"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="40" id="Z53-oy-Z0X"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="Zkp-tY-L3b" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="0Sx-JW-U29"/>
+                                            <constraint firstItem="bqn-VN-Tor" firstAttribute="top" secondItem="YTZ-Cj-OlK" secondAttribute="bottom" constant="15" id="1Rt-ym-mlV"/>
+                                            <constraint firstItem="LYX-7s-QZm" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="3NG-1t-WMU"/>
+                                            <constraint firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" constant="30" id="3Vd-F0-B5q"/>
+                                            <constraint firstItem="Zor-P6-dOg" firstAttribute="height" secondItem="OGH-La-UYF" secondAttribute="height" id="4Qa-O7-OHr"/>
+                                            <constraint firstItem="OGH-La-UYF" firstAttribute="leading" secondItem="LYX-7s-QZm" secondAttribute="leading" id="6HL-y7-iga"/>
+                                            <constraint firstItem="YTZ-Cj-OlK" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="6Qb-fN-XFC"/>
+                                            <constraint firstItem="YTZ-Cj-OlK" firstAttribute="top" secondItem="Zkp-tY-L3b" secondAttribute="bottom" constant="10" id="7tH-aE-9Wb"/>
+                                            <constraint firstAttribute="height" constant="370" id="COL-N7-1eY"/>
+                                            <constraint firstItem="bqn-VN-Tor" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="Fzb-B4-8Gt"/>
+                                            <constraint firstItem="Zkp-tY-L3b" firstAttribute="top" secondItem="KBu-NN-IBT" secondAttribute="top" constant="30" id="Lbd-N8-lUz"/>
+                                            <constraint firstItem="FAp-vT-8Dg" firstAttribute="leading" secondItem="fep-fT-o8f" secondAttribute="leading" id="PGA-fu-XnY"/>
+                                            <constraint firstItem="fep-fT-o8f" firstAttribute="top" secondItem="vWc-Dp-Ld6" secondAttribute="bottom" constant="30" id="SAN-8J-twf"/>
+                                            <constraint firstItem="Zor-P6-dOg" firstAttribute="leading" secondItem="36S-A7-2p0" secondAttribute="trailing" constant="20" id="XuV-kO-d1G"/>
+                                            <constraint firstItem="36S-A7-2p0" firstAttribute="height" secondItem="OGH-La-UYF" secondAttribute="height" id="Zqa-EL-Y2d"/>
+                                            <constraint firstItem="Rvs-IB-hfe" firstAttribute="centerY" secondItem="FAp-vT-8Dg" secondAttribute="centerY" id="b1a-8P-Zqh"/>
+                                            <constraint firstItem="OGH-La-UYF" firstAttribute="top" secondItem="LYX-7s-QZm" secondAttribute="bottom" constant="20" id="e1P-wd-o5s"/>
+                                            <constraint firstItem="FAp-vT-8Dg" firstAttribute="top" secondItem="fep-fT-o8f" secondAttribute="bottom" constant="15" id="hTr-e0-DbH"/>
+                                            <constraint firstItem="fep-fT-o8f" firstAttribute="leading" secondItem="LYX-7s-QZm" secondAttribute="leading" id="k7R-x7-LW8"/>
+                                            <constraint firstItem="vWc-Dp-Ld6" firstAttribute="top" secondItem="OGH-La-UYF" secondAttribute="bottom" constant="25" id="lV1-oB-BdY"/>
+                                            <constraint firstItem="vWc-Dp-Ld6" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" constant="30" id="oZX-Jn-reb"/>
+                                            <constraint firstItem="Zor-P6-dOg" firstAttribute="centerY" secondItem="36S-A7-2p0" secondAttribute="centerY" id="ujs-tC-aNZ"/>
+                                            <constraint firstAttribute="trailing" secondItem="vWc-Dp-Ld6" secondAttribute="trailing" constant="30" id="uo1-7v-sJn"/>
+                                            <constraint firstItem="36S-A7-2p0" firstAttribute="centerY" secondItem="OGH-La-UYF" secondAttribute="centerY" id="y8k-Hp-X4G"/>
+                                            <constraint firstItem="36S-A7-2p0" firstAttribute="leading" secondItem="OGH-La-UYF" secondAttribute="trailing" constant="20" id="ypd-8k-b02"/>
+                                            <constraint firstItem="LYX-7s-QZm" firstAttribute="top" secondItem="bqn-VN-Tor" secondAttribute="bottom" constant="30" id="zIR-Ro-Lmp"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x0u-Zu-Z2T" userLabel="secondView">
+                                        <rect key="frame" x="25" y="390" width="325" height="152"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" red="0.97647064920000004" green="0.97647064920000004" blue="0.97647064920000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="4IP-I2-TnE"/>
+                                    <constraint firstItem="x0u-Zu-Z2T" firstAttribute="trailing" secondItem="KBu-NN-IBT" secondAttribute="trailing" id="HCI-kK-5Zw"/>
+                                    <constraint firstItem="x0u-Zu-Z2T" firstAttribute="leading" secondItem="KBu-NN-IBT" secondAttribute="leading" id="O7q-yk-DNh"/>
+                                    <constraint firstItem="KBu-NN-IBT" firstAttribute="leading" secondItem="XJM-jO-aJv" secondAttribute="leading" constant="25" id="Tdf-Yd-wUF"/>
+                                    <constraint firstAttribute="bottom" secondItem="x0u-Zu-Z2T" secondAttribute="bottom" id="ZKk-G9-qSE"/>
+                                    <constraint firstAttribute="trailing" secondItem="KBu-NN-IBT" secondAttribute="trailing" constant="25" id="ZqM-OC-l9F"/>
+                                    <constraint firstItem="x0u-Zu-Z2T" firstAttribute="top" secondItem="KBu-NN-IBT" secondAttribute="bottom" constant="20" id="icd-Ye-GpT"/>
+                                    <constraint firstItem="KBu-NN-IBT" firstAttribute="top" secondItem="XJM-jO-aJv" secondAttribute="top" id="ndY-nS-OIH"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bqn-VN-Tor" userLabel="divider">
-                                <rect key="frame" x="30" y="191.5" width="305" height="0.5"/>
-                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="0.5" id="pmi-D0-m4I"/>
-                                </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="카테고리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LYX-7s-QZm">
-                                <rect key="frame" x="30" y="217" width="63" height="22"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZOl-gp-hwe" userLabel="divider">
-                                <rect key="frame" x="30" y="319" width="305" height="0.5"/>
-                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="0.5" id="Zud-S8-j5Y"/>
-                                </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기한" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Zx-Rb-dO4">
-                                <rect key="frame" x="30" y="344.5" width="32" height="22"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022년 5월 14일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0lG-ap-Ftm">
-                                <rect key="frame" x="30" y="386.5" width="112" height="18"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10:00 PM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ame-vd-1FK">
-                                <rect key="frame" x="265.5" y="386.5" width="69.5" height="18"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rz5-I6-te4" userLabel="divider">
-                                <rect key="frame" x="30" y="424.5" width="305" height="0.5"/>
-                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="0.5" id="zRw-da-eh6"/>
-                                </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="예상시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jui-1H-VJk">
-                                <rect key="frame" x="30" y="445" width="63" height="22"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="* 이 일이 끝나기 위해서 필요한 시간을 예상해서 작성해주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fiK-Ew-5QR">
-                                <rect key="frame" x="30" y="477" width="296" height="14.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="6시간 30분" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Yg-we-oIH">
-                                <rect key="frame" x="30" y="511.5" width="73" height="18"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cbx-l9-SJO" userLabel="divider">
-                                <rect key="frame" x="30" y="549.5" width="305" height="0.5"/>
-                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="0.5" id="QnG-gd-QJb"/>
-                                </constraints>
-                            </imageView>
+                            </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dae-6q-WZV">
-                                <rect key="frame" x="30" y="592" width="305" height="45"/>
+                                <rect key="frame" x="30" y="592" width="315" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="LcG-yd-n15"/>
                                 </constraints>
@@ -231,46 +283,20 @@
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="KYH-Jd-olP"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0.97647064920000004" green="0.97647064920000004" blue="0.97647064920000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="KYH-Jd-olP" firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" constant="40" id="2B1-fU-n83"/>
-                            <constraint firstItem="dg3-sz-GwB" firstAttribute="top" secondItem="KYH-Jd-olP" secondAttribute="top" constant="15" id="2cZ-Km-ipm"/>
-                            <constraint firstItem="yH0-gl-Km4" firstAttribute="top" secondItem="dg3-sz-GwB" secondAttribute="bottom" constant="20" id="6DN-D6-faj"/>
-                            <constraint firstItem="LYX-7s-QZm" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="7d6-bU-Qh4"/>
+                            <constraint firstItem="dg3-sz-GwB" firstAttribute="top" secondItem="KYH-Jd-olP" secondAttribute="top" constant="20" id="2cZ-Km-ipm"/>
+                            <constraint firstItem="KYH-Jd-olP" firstAttribute="trailing" secondItem="XJM-jO-aJv" secondAttribute="trailing" id="4j8-9A-cXy"/>
+                            <constraint firstItem="yH0-gl-Km4" firstAttribute="top" secondItem="dg3-sz-GwB" secondAttribute="bottom" constant="10" id="6DN-D6-faj"/>
                             <constraint firstItem="dg3-sz-GwB" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" constant="5" id="8a6-wn-VL6"/>
-                            <constraint firstItem="ZOl-gp-hwe" firstAttribute="top" secondItem="LYX-7s-QZm" secondAttribute="bottom" constant="80" id="AAA-5a-Wl3"/>
-                            <constraint firstItem="rz5-I6-te4" firstAttribute="leading" secondItem="bqn-VN-Tor" secondAttribute="leading" id="DOf-ZV-7K8"/>
-                            <constraint firstItem="Zkp-tY-L3b" firstAttribute="top" secondItem="yH0-gl-Km4" secondAttribute="bottom" constant="40" id="El2-mC-6y7"/>
-                            <constraint firstItem="ZOl-gp-hwe" firstAttribute="leading" secondItem="bqn-VN-Tor" secondAttribute="leading" id="Hhi-SE-vFR"/>
-                            <constraint firstItem="Dae-6q-WZV" firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" id="IYy-Ve-rFy"/>
-                            <constraint firstItem="YTZ-Cj-OlK" firstAttribute="centerY" secondItem="Zkp-tY-L3b" secondAttribute="centerY" id="Im3-Cl-nly"/>
-                            <constraint firstItem="Ame-vd-1FK" firstAttribute="centerY" secondItem="0lG-ap-Ftm" secondAttribute="centerY" id="IuH-Fw-cJ3"/>
-                            <constraint firstItem="8Zx-Rb-dO4" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="JfG-Wx-qiN"/>
-                            <constraint firstItem="5Yg-we-oIH" firstAttribute="leading" secondItem="Jui-1H-VJk" secondAttribute="leading" id="Jtt-cg-6CR"/>
-                            <constraint firstItem="Jui-1H-VJk" firstAttribute="top" secondItem="rz5-I6-te4" secondAttribute="bottom" constant="20" id="KCq-yy-WsD"/>
-                            <constraint firstItem="bqn-VN-Tor" firstAttribute="top" secondItem="Zkp-tY-L3b" secondAttribute="bottom" constant="25" id="KnD-SM-8Ok"/>
-                            <constraint firstItem="Cbx-l9-SJO" firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" id="MIg-Y6-dQh"/>
-                            <constraint firstItem="fiK-Ew-5QR" firstAttribute="top" secondItem="Jui-1H-VJk" secondAttribute="bottom" constant="10" id="Mbb-LJ-v40"/>
-                            <constraint firstItem="Cbx-l9-SJO" firstAttribute="leading" secondItem="bqn-VN-Tor" secondAttribute="leading" id="NJz-We-u3E"/>
-                            <constraint firstItem="YTZ-Cj-OlK" firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" id="OL3-Ep-GZe"/>
-                            <constraint firstItem="Dae-6q-WZV" firstAttribute="leading" secondItem="bqn-VN-Tor" secondAttribute="leading" id="Qnc-sG-NsZ"/>
-                            <constraint firstItem="5Yg-we-oIH" firstAttribute="top" secondItem="fiK-Ew-5QR" secondAttribute="bottom" constant="20" id="RSW-mV-1xi"/>
-                            <constraint firstItem="ZOl-gp-hwe" firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" id="SY2-4Z-JZe"/>
-                            <constraint firstItem="Ame-vd-1FK" firstAttribute="trailing" secondItem="ZOl-gp-hwe" secondAttribute="trailing" id="WJj-HS-lpg"/>
-                            <constraint firstItem="0lG-ap-Ftm" firstAttribute="bottom" secondItem="rz5-I6-te4" secondAttribute="top" constant="-20" id="WMr-Yq-jgI"/>
-                            <constraint firstItem="Jui-1H-VJk" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="ZDe-hc-vVP"/>
-                            <constraint firstItem="fiK-Ew-5QR" firstAttribute="leading" secondItem="Jui-1H-VJk" secondAttribute="leading" id="cAJ-vM-A9i"/>
-                            <constraint firstItem="0lG-ap-Ftm" firstAttribute="top" secondItem="8Zx-Rb-dO4" secondAttribute="bottom" constant="20" id="cEf-cZ-q1w"/>
-                            <constraint firstItem="bqn-VN-Tor" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="leading" id="cv8-Ty-NUW"/>
-                            <constraint firstItem="LYX-7s-QZm" firstAttribute="top" secondItem="bqn-VN-Tor" secondAttribute="bottom" constant="25" id="eUe-zv-IMq"/>
+                            <constraint firstItem="KBu-NN-IBT" firstAttribute="trailing" secondItem="Rvs-IB-hfe" secondAttribute="trailing" constant="30" id="FaO-Yy-5Jy"/>
                             <constraint firstItem="KYH-Jd-olP" firstAttribute="bottom" secondItem="Dae-6q-WZV" secondAttribute="bottom" constant="30" id="fnp-Xr-IKx"/>
-                            <constraint firstItem="YTZ-Cj-OlK" firstAttribute="leading" secondItem="Zkp-tY-L3b" secondAttribute="trailing" constant="40" id="gZh-qp-VEN"/>
-                            <constraint firstItem="8Zx-Rb-dO4" firstAttribute="top" secondItem="ZOl-gp-hwe" secondAttribute="bottom" constant="25" id="gck-7I-O96"/>
-                            <constraint firstItem="Zkp-tY-L3b" firstAttribute="leading" secondItem="yH0-gl-Km4" secondAttribute="leading" id="oK0-BL-8Sz"/>
+                            <constraint firstItem="Dae-6q-WZV" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" constant="30" id="n8J-1z-5tm"/>
+                            <constraint firstItem="XJM-jO-aJv" firstAttribute="top" secondItem="yH0-gl-Km4" secondAttribute="bottom" constant="15" id="rJh-or-dtg"/>
                             <constraint firstItem="yH0-gl-Km4" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" constant="30" id="sop-SS-ncC"/>
-                            <constraint firstItem="0lG-ap-Ftm" firstAttribute="leading" secondItem="8Zx-Rb-dO4" secondAttribute="leading" id="uax-Yr-lJF"/>
-                            <constraint firstItem="5Yg-we-oIH" firstAttribute="bottom" secondItem="Cbx-l9-SJO" secondAttribute="top" constant="-20" id="vV0-6l-2Zk"/>
-                            <constraint firstItem="rz5-I6-te4" firstAttribute="trailing" secondItem="bqn-VN-Tor" secondAttribute="trailing" id="xb8-Ot-ECC"/>
+                            <constraint firstItem="XJM-jO-aJv" firstAttribute="leading" secondItem="KYH-Jd-olP" secondAttribute="leading" id="ujx-J9-q8A"/>
+                            <constraint firstItem="KYH-Jd-olP" firstAttribute="bottom" secondItem="XJM-jO-aJv" secondAttribute="bottom" id="vAR-4X-02g"/>
+                            <constraint firstItem="KYH-Jd-olP" firstAttribute="trailing" secondItem="Dae-6q-WZV" secondAttribute="trailing" constant="30" id="wAz-46-Pct"/>
                         </constraints>
                         <connections>
                             <outlet property="addTaskButton" destination="Dae-6q-WZV" id="7hP-dX-OID"/>
@@ -281,7 +307,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jAF-6p-amF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="876" y="109"/>
+            <point key="canvasLocation" x="876" y="108.39580209895054"/>
         </scene>
         <!--Tomorrow Child View Controller-->
         <scene sceneID="tne-QT-ifu">


### PR DESCRIPTION
# [feature/addTaskView] AddTaskVC에 StackView 적용  
## 개발 환경  
* Xcode 13.4  
* iOS 15.4.1  
* iPhone SE  

## 상세 설명   
<img width="500" alt="2" src="https://user-images.githubusercontent.com/63276842/170414940-2cf34239-46b1-4dd5-b72b-a29ded13e997.png">  

### StackView  
* 각 카드 영역을 하나의 View로 만들어 StackView에 쌓고, View마다 일정한 간격을 두어 관리  
  * firstView: 이름, 카테고리, 마감기한(시간)  
  * secondView: 예상 필요시간  

### DatePicker
* 마감기한, 시간, 예상 필요시간을 입력받을 때 각각 다른 DatePicker을 이용하여 입력받음  
  * 마감기한 -> `.date`, `.inline`
  * 시간 -> `time`, `.wheels`  
  * 예상 필요시간 -> `countDownTimer`, `.automatic`  
* `cancel`, `done` 버튼이 포함되어 있는 toolbar를 DatePicker 상단에 붙여서 배치   

### 키보드 입력 시 화면 조정  
* `Observer`를 활용하여 키보드 입력이 있을 경우, `self.view.frame.origin.y`를 조정하여 textField가 가려지지 않도록 조정  
* `tapGesture`를 활용하여, 키보드 입력 시 유저가 다른 화면을 탭 할 경우 키보드를 dismiss할 수 있도록 구현  